### PR TITLE
AB#26 - Updated design for collections landing page

### DIFF
--- a/public/assets/javascripts/nyc-core-framework.js
+++ b/public/assets/javascripts/nyc-core-framework.js
@@ -118,3 +118,41 @@ function fireEvent(element, event) {
         return !element.dispatchEvent(evt);
     }
 }
+// Display collections in ascending/descending order
+$('#collection_title').click(function(){
+    var isSelected = $("#sort option[value='title_sort desc']").attr("selected");
+    //Sort records by title in ascending order
+    if (typeof isSelected !== typeof undefined && isSelected !== false)
+    {
+        $("#sort option[value='title_sort asc']").attr("selected","selected");
+        $("#sort option[value='title_sort desc']").removeAttr("selected");
+        $("#sort_form").submit();
+    }
+    //Sort records by title in descending order
+    else
+    {
+        $("#sort option[value='title_sort desc']").attr("selected","selected");
+        $("#sort option[value='title_sort asc']").removeAttr("selected");
+        $("#sort_form").submit();
+    }
+});
+//Sort records by date in descending order
+$('#collection_year').click(function(){
+    var isSelected = $("#sort option[value='year_sort desc']").attr("selected");
+    //Sort records by date in ascending order
+
+    if (typeof isSelected !== typeof undefined && isSelected !== false) {
+        $("#sort option[value='year asc']").attr("selected", "selected");
+        $("#sort option[value='year_sort desc']").removeAttr("selected");
+        $("#sort_form").submit();
+        $("#year-sort-icon").attr("class","fa fa-lg fa-caret-up");
+    }
+    //Sort records by date in descending order
+    else {
+        $("#sort option[value='year_sort desc']").attr("selected", "selected");
+        $("#sort option[value='year_sort asc']").removeAttr("selected");
+        $("#year-sort-icon").attr("class","fa fa-lg fa-caret-down");
+        $("#sort_form").submit();
+
+    }
+});

--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -120,7 +120,6 @@ Rails.application.config.after_initialize do
       end
       page = Integer(params.fetch(:page, "1"))
       facet_types =  %w{primary_type subjects published_agents}
-      facet_types.unshift('repository') if !@repo_id
       begin
         set_up_and_run_search(['resource'], facet_types, search_opts, params)
       rescue NoResultsError

--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -101,4 +101,63 @@ Rails.application.config.after_initialize do
       render 'search/agents_search_results'
     end
   end
+
+  class ResourcesController
+    # present a list of resources.  If no repository named, just get all of them.
+    def index
+      @repo_id = params.fetch(:rid, nil)
+      if @repo_id
+        @base_search = "/repositories/#{@repo_id}/resources?"
+        repo = archivesspace.get_record("/repositories/#{@repo_id}")
+        @repo_name = repo.display_string
+      else
+        @base_search = "/repositories/resources?"
+      end
+      search_opts = default_search_opts( DEFAULT_RES_INDEX_OPTS)
+      search_opts['fq'] = ["repository:\"/repositories/#{@repo_id}\""] if @repo_id
+      DEFAULT_RES_SEARCH_PARAMS.each do |k,v|
+        params[k] = v unless params.fetch(k, nil)
+      end
+      page = Integer(params.fetch(:page, "1"))
+      facet_types =  %w{primary_type subjects published_agents}
+      facet_types.unshift('repository') if !@repo_id
+      begin
+        set_up_and_run_search(['resource'], facet_types, search_opts, params)
+      rescue NoResultsError
+        flash[:error] = I18n.t('search_results.no_results')
+        redirect_back(fallback_location: '/') and return
+      rescue Exception => error
+        flash[:error] = I18n.t('errors.unexpected_error')
+        redirect_back(fallback_location: '/' ) and return
+      end
+
+      @context = repo_context(@repo_id, 'resource')
+      if @results['total_hits'] > 1
+        @search[:dates_within] = true if params.fetch(:filter_from_year,'').blank? && params.fetch(:filter_to_year,'').blank?
+        @search[:text_within] = true
+      end
+      @page_title = I18n.t('resource._plural')
+      @results_type = @page_title
+      @sort_opts = []
+      all_sorts = Search.get_sort_opts
+      all_sorts.delete('relevance') unless params[:q].size > 1 || params[:q] != '*'
+      all_sorts.keys.each do |type|
+        @sort_opts.push(all_sorts[type])
+      end
+
+      if params[:q].size > 1 || params[:q][0] != '*'
+        @sort_opts.unshift(all_sorts['relevance'])
+      end
+      @result_props = {
+          :no_res => true
+      }
+      @no_statement = true
+      #    if @results['results'].length == 1
+      #      @result =  @results['results'][0]
+      #      render 'resources/show'
+      #    else
+      render 'search/resources_search_results'
+      #    end
+    end
+  end
 end

--- a/public/views/landing/agents/_agents_result.html.erb
+++ b/public/views/landing/agents/_agents_result.html.erb
@@ -1,94 +1,94 @@
- <%# any result that is going to be presented in a list %>
- <%# Pry::ColorPrinter.pp(result['json'])%>
+<%# any result that is going to be presented in a list %>
+<%# Pry::ColorPrinter.pp(result['json'])%>
 
- <% if !props.fetch(:full,false) %>
-   <div class="recordrow" style="clear:both" data-uri="<%= result.uri %>">
- <% end %>
- <%= render partial: 'landing/agents/agents_idbadge', locals: {:result => result, :props => props } %>
- <div class="recordsummary" style="clear:both">
-   <% if !result['parent_institution_name'].blank? %>
-     <div>
-       <strong><%= t('parent_inst') %>:</strong>
-       <%= result['parent_institution_name'] %>
-     </div>
-   <% end %>
+<% if !props.fetch(:full,false) %>
+  <div class="recordrow h-100" style="clear:both;" data-uri="<%= result.uri %>">
+<% end %>
+<%= render partial: 'landing/agents/agents_idbadge', locals: {:result => result, :props => props } %>
+<div class="recordsummary" style="clear:both">
+  <% if !result['parent_institution_name'].blank? %>
+    <div>
+      <strong><%= t('parent_inst') %>:</strong>
+      <%= result['parent_institution_name'] %>
+    </div>
+  <% end %>
 
-   <% note_struct = result.note('abstract')
-	  if note_struct.blank?
-	    note_struct = result.note('scopecontent')
-          end
-	  if !note_struct['note_text'].blank? %>
-      <div class="abstract single_note"><span class='inline-label'><%= note_struct['label'] %></span>
-        <% unless note_struct['is_inherited'].blank? %>
-          <%= inheritance(note_struct['is_inherited']).html_safe %>
-        <% end %>
-        <% if note_struct['note_text'].length > AppConfig[:abstract_note_length] %>
-           <% truncated_note = note_struct['note_text'][0..AppConfig[:abstract_note_length]-1] %>
-           <% end_index = truncated_note.rindex(' ') || AppConfig[:abstract_note_length]-1 %>
-           <%= (strip_tags(truncated_note[0..end_index - 1]) + '...').html_safe %>
-        <% else %>
-	        <%= note_struct['note_text'].html_safe %>
-        <% end %>
-      </div>
-    <% end %>
-   <% unless props.fetch(:no_repo, false) %>
-     <% r_uri = nil
-        r_name = nil
-        if result['json']['repository'] && result['json']['repository']['_resolved'] && (!result['json']['repository']['ref'].blank? || !result['json']['repository']['_resolved']['name'].blank?)
-          r_uri = result['json']['repository']['ref'] || ''
-          r_name = result['json']['repository']['_resolved']['name'] || ''
-        elsif result['_resolved_repository'] && result['_resolved_repository']['json']
-          r_uri =  result['_resolved_repository']['json']['uri'] || ''
-          r_name = result['_resolved_repository']['json']['name'] || ''
-        end
-     %>
-   <% end %>
+  <% note_struct = result.note('abstract')
+     if note_struct.blank?
+       note_struct = result.note('scopecontent')
+     end
+     if !note_struct['note_text'].blank? %>
+    <div class="abstract single_note"><span class='inline-label'><%= note_struct['label'] %></span>
+      <% unless note_struct['is_inherited'].blank? %>
+        <%= inheritance(note_struct['is_inherited']).html_safe %>
+      <% end %>
+      <% if note_struct['note_text'].length > AppConfig[:abstract_note_length] %>
+        <% truncated_note = note_struct['note_text'][0..AppConfig[:abstract_note_length]-1] %>
+        <% end_index = truncated_note.rindex(' ') || AppConfig[:abstract_note_length]-1 %>
+        <%= (strip_tags(truncated_note[0..end_index - 1]) + '...').html_safe %>
+      <% else %>
+        <%= note_struct['note_text'].html_safe %>
+      <% end %>
+    </div>
+  <% end %>
+  <% unless props.fetch(:no_repo, false) %>
+    <% r_uri = nil
+       r_name = nil
+       if result['json']['repository'] && result['json']['repository']['_resolved'] && (!result['json']['repository']['ref'].blank? || !result['json']['repository']['_resolved']['name'].blank?)
+         r_uri = result['json']['repository']['ref'] || ''
+         r_name = result['json']['repository']['_resolved']['name'] || ''
+       elsif result['_resolved_repository'] && result['_resolved_repository']['json']
+         r_uri =  result['_resolved_repository']['json']['uri'] || ''
+         r_name = result['_resolved_repository']['json']['name'] || ''
+       end
+    %>
+  <% end %>
 
-    <% if result.resolved_repository %>
-      <div class="result_context">
-        <strong><%= t('context') %>: </strong>
-        <span  class="repo_name">
+  <% if result.resolved_repository %>
+    <div class="result_context">
+      <strong><%= t('context') %>: </strong>
+      <span  class="repo_name">
           <%= link_to result.resolved_repository.fetch('name'),
-                     app_prefix(repository_base_url(
-                      "uri" => result.resolved_repository.fetch('uri'),
-                      "slug" => result.resolved_repository.fetch('slug') {|s| nil })) %>
+                      app_prefix(repository_base_url(
+                                     "uri" => result.resolved_repository.fetch('uri'),
+                                     "slug" => result.resolved_repository.fetch('slug') {|s| nil })) %>
         </span>
 
-        <% if result.respond_to?(:ancestors) && result.ancestors %>
-          <% result.ancestors.each do |ancestor| %>
-            <%= t('context_delimiter') %>
-            <span class="ancestor">
+      <% if result.respond_to?(:ancestors) && result.ancestors %>
+        <% result.ancestors.each do |ancestor| %>
+          <%= t('context_delimiter') %>
+          <span class="ancestor">
             <% identifier = ancestor.has_key?('id_0') ? (0..3).collect { |i| ancestor["id_#{i}"] }.compact.join('-') : nil %>
             <% title = process_mixed_content(ancestor.fetch('title', "[#{ ancestor.fetch('level', 'untitled')}]" )).html_safe %>
             <%= link_to (identifier.blank? ? title : "#{identifier}, #{title}"), app_prefix(ancestor.fetch('uri')) %>
             </span>
-          <% end %>
-        <% else %>
-          <% unless props.fetch(:no_res, false) || result.resolved_resource.blank? %>
-            <%= t('context_delimiter') %>
-            <span class="resource_name">
+        <% end %>
+      <% else %>
+        <% unless props.fetch(:no_res, false) || result.resolved_resource.blank? %>
+          <%= t('context_delimiter') %>
+          <span class="resource_name">
               <%= link_to process_mixed_content(result.resolved_resource.fetch('title')).html_safe, app_prefix(result.resolved_resource.fetch('uri')) %>
             </span>
-          <% end %>
         <% end %>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
+  <% end %>
 
-       <% if !props.fetch(:full,false)  && result['primary_type'] == 'repository' %>
-       <div><strong><%= t('number_of', { :type => t('resource._plural') }) %></strong> <%= @counts[result.uri]['resource'] %></div>
-       <% end %>
+  <% if !props.fetch(:full,false)  && result['primary_type'] == 'repository' %>
+    <div><strong><%= t('number_of', { :type => t('resource._plural') }) %></strong> <%= @counts[result.uri]['resource'] %></div>
+  <% end %>
 
-     <% if result.primary_type == 'classification' && result.classification_terms? %>
-     <div class="classification-subgroups">
-       <button class="btn btn-default btn-sm subgroup-toggle" aria-pressed="false">
-         <i aria-hidden="true" class="fa fa-plus"></i>
-         <%= t('classification._public.actions.show_subgroups') %>
-       </button>
-       <div class="classification-subgroups-tree largetree-container" style="display: none;"></div>
-     </div>
-     <% end %>
-   </div>
+  <% if result.primary_type == 'classification' && result.classification_terms? %>
+    <div class="classification-subgroups">
+      <button class="btn btn-default btn-sm subgroup-toggle" aria-pressed="false">
+        <i aria-hidden="true" class="fa fa-plus"></i>
+        <%= t('classification._public.actions.show_subgroups') %>
+      </button>
+      <div class="classification-subgroups-tree largetree-container" style="display: none;"></div>
+    </div>
+  <% end %>
+</div>
 
 <% if !props.fetch(:full,false) %>
-   </div>
+  </div>
 <% end %>

--- a/public/views/landing/resources/_only_facets.html.erb
+++ b/public/views/landing/resources/_only_facets.html.erb
@@ -1,0 +1,106 @@
+<% unless @facets.blank? %>
+  <%facets_type= Hash.new %>
+  <%h=Hash.new%>
+  <dl id="facets">
+    <%
+      preferred_facet_order = %w(repository primary_type agents subjects)
+      ordered_facet_types = @facets.keys.sort{|a,b|
+        if preferred_facet_order.include?(a) && preferred_facet_order.include?(b)
+          preferred_facet_order.index(a) <=> preferred_facet_order.index(b)
+        elsif preferred_facet_order.include?(a)
+          -1
+        elsif preferred_facet_order.include?(b)
+          1
+        else
+          0
+        end
+      }
+    %>
+
+    <%ordered_facet_types.each do |type| %>
+      <% h.merge!@facets.fetch(type, false) %>
+    <%end %>
+        <%
+          # Creating a hash with sub-types as key and facets as values
+          h.each do |v, ct|
+            #Splitting facets with multiple sub-types
+            if(v.include? "--")
+              split_string = v.split("--")
+              split_string.each do |sub_part|
+                sub_part = sub_part.strip
+                if facets_type.has_key?(type_info[sub_part])
+                  facets_type[type_info[sub_part]][v] =ct
+                else
+                  facets_type[type_info[sub_part]] = Hash.new
+                  facets_type[type_info[sub_part]][v] =ct
+                end
+              end
+              next
+            end
+            if facets_type.has_key?(type_info[v])
+              facets_type[type_info[v]][v] =ct
+            else
+              facets_type[type_info[v]] = Hash.new
+              facets_type[type_info[v]][v] =ct
+            end
+          end %>
+      <%facets_type.each do |facet_type,h| %>
+
+        <% if(facet_type == "temporal")
+             next
+           end
+          next unless h %>
+        <% case facet_type
+            when "topical"
+              title = "Topic"
+              type="subjects"
+           when "genre_form"
+             title = "Material Type"
+             type="subjects"
+           when "geographic"
+             title = "Location"
+             type="subjects"
+           when "occupation"
+             title = "Occupation"
+             type="subjects"
+           when "name_person"
+             title = "People"
+              type="published_agents"
+           when "name_corporate_entity"
+             title = "Organizations"
+              type="published_agents"
+              end
+        %>
+        <h3 class="h5"><%=title %></h3>
+        <ul class="small">
+          <% facet_count = 0 %>
+          <!-- Sorting values by title -->
+          <% h = h.sort_by { |key| key }.to_h %>
+
+          <% h.each do |v, ct| %>
+            <% if facet_count == 5 %>
+              <div class="more-facets">
+                <button class="more btn btn-outline-dark btn-sm mt-2"> more &nbsp;<span class="fa fa-sm fa-plus"></span></button>
+                <div class="below-the-fold" style="display:none">
+            <% end %>
+            <% facet_count += 1 %>
+            <li>
+              <a href="<%= app_prefix("#{@page_search}&filter_fields[]=#{type}&filter_values[]=#{CGI.escape(v)}") %>"
+                 rel="nofollow"
+                 title="<%= t('search_results.filter_by')%> '<%= get_pretty_facet_value(type,v) %>'">
+                <%= get_pretty_facet_value(type,v) %>
+              </a>
+              <span class="recordnumber"><b>(<%= ct %>)</b></span>
+            </li>
+          <% end %>
+
+          <% if facet_count > 5 %>
+            <button class="less btn btn-outline-dark btn-sm mt-2"> less &nbsp;<span class="fa fa-sm fa-minus"></span></button>
+            </div>
+          <% end %>
+          <span class="type-spacer">&nbsp;</span>
+        </ul>
+        <% h.clear %>
+      <% end %>
+  </dl>
+<% end %>

--- a/public/views/landing/resources/_only_facets.html.erb
+++ b/public/views/landing/resources/_only_facets.html.erb
@@ -87,7 +87,7 @@
             <li>
               <a href="<%= app_prefix("#{@page_search}&filter_fields[]=#{type}&filter_values[]=#{CGI.escape(v)}") %>"
                  rel="nofollow"
-                 title="<%= t('search_results.filter_by')%> '<%= get_pretty_facet_value(type,v) %>'">
+                 title="<%= t('search_results.filter_by')%> <%= get_pretty_facet_value(type,v) %>'">
                 <%= get_pretty_facet_value(type,v) %>
               </a>
               <span class="recordnumber"><b>(<%= ct %>)</b></span>

--- a/public/views/landing/resources/_resources_idbadge.html.erb
+++ b/public/views/landing/resources/_resources_idbadge.html.erb
@@ -44,7 +44,7 @@
     <%== props.fetch(:infinite_item, false) ? result.parse_full_title(true) : result.display_string %>
   </a>
   <% comp_id = display_component_id(result, props.fetch(:infinite_item, false)) %>
-  <small><%= comp_id %></small>
+  <small><%=t('resource._singular') %> <%= comp_id %></small>
 <% else %>
   <%== result.display_string %>
 <% end %>

--- a/public/views/landing/resources/_resources_idbadge.html.erb
+++ b/public/views/landing/resources/_resources_idbadge.html.erb
@@ -38,22 +38,13 @@
   <% url = result.uri %>
 <% end %>
 
-<%= (props.fetch(:full,false)? '<h1>' : '<h3 class="h-100">').html_safe %>
+<%= (props.fetch(:full,false)? '<h1>' : '<h3>').html_safe %>
 <% if !props.fetch(:full,false) %>
-  <div class="card m-2 h-100">
-    <button class="btn btn-md btn-light text-primary h-100 mx-1 my-2">
-      <% if result['json']['jsonmodel_type'] == "agent_corporate_entity" %>
-          <span class="fa fa-university">
-          </span>
-      <%else %>
-          <span class="fa fa-user">
-          </span>
-      <%end %>
-      <a  href="<%= app_prefix(url) %>">
-        <%== props.fetch(:infinite_item, false) ? result.parse_full_title(true) : result.display_string %>
-      </a>
-    </button>
-  </div>
+  <a class="record-title" href="<%= app_prefix(url) %>">
+    <%== props.fetch(:infinite_item, false) ? result.parse_full_title(true) : result.display_string %>
+  </a>
+  <% comp_id = display_component_id(result, props.fetch(:infinite_item, false)) %>
+  <small><%= comp_id %></small>
 <% else %>
   <%== result.display_string %>
 <% end %>

--- a/public/views/landing/resources/_resources_result.html.erb
+++ b/public/views/landing/resources/_resources_result.html.erb
@@ -1,0 +1,36 @@
+<%# any result that is going to be presented in a list %>
+<%# Pry::ColorPrinter.pp(result['json'])%>
+<tr>
+<% if !props.fetch(:full,false) %>
+  <td class="p-2">
+    <a href="<%= result.uri %>"></a>
+<% end %>
+<%= render partial: 'landing/resources/resources_idbadge', locals: {:result => result, :props => props } %>
+
+<p>
+  <% note_struct = result.note('abstract')
+    if note_struct.blank?
+     note_struct = result.note('scopecontent')
+    end
+    if !note_struct['note_text'].blank? %>
+        <% unless note_struct['is_inherited'].blank? %>
+          <%= inheritance(note_struct['is_inherited']).html_safe %>
+        <% end %>
+        <% if note_struct['note_text'].length > AppConfig[:abstract_note_length] %>
+          <% truncated_note = note_struct['note_text'][0..AppConfig[:abstract_note_length]-1] %>
+          <% end_index = truncated_note.rindex(' ') || AppConfig[:abstract_note_length]-1 %>
+          <%= (strip_tags(truncated_note[0..end_index - 1]) + '...').html_safe %>
+        <% else %>
+          <%= note_struct['note_text'].html_safe %>
+        <% end %>
+    <% end %>
+</p>
+  </td>
+  <td>
+    <% if result['json'].has_key?('dates') || result['json'].has_key?('dates_of_existence') %>
+        <% dates = (result['json']['dates'] || result['json']['dates_of_existence']
+        ).collect {|date| parse_date(date)}.reject{|label, expression| expression.blank?} %>
+        <%= dates[0][1] %>
+    <% end %>
+  </td>
+</tr>

--- a/public/views/search/agents_search_results.html.erb
+++ b/public/views/search/agents_search_results.html.erb
@@ -1,11 +1,13 @@
 <% results_type = (defined?(@results_type) ? @results_type : t('search_results.results')) %>
+<%index_range = Array.new %>
+
 <div class="row">
   <div class="col-sm-12">
     <%= render partial: 'shared/breadcrumbs' %>
   </div>
 </div>
-<% if defined?(@results) %>
-  <% params.has_key?(:begins_with) ? search_char =params[:begins_with] : search_char= 'A' %>
+<% if defined?(@results)
+     params.has_key?(:begins_with) ? search_char =params[:begins_with] : search_char= 'A' %>
   <div class="row">
     <div class="col-12">
       <a name="main" title="<%= t('internal_links.main') %>"></a>
@@ -16,24 +18,33 @@
               <div id="azindex">
                 <ul id="index">
                   <ul>
-                    <% index_range = 'A'..'Z' %>
+                    <% ('A'..'Z').each do |index_char|
+                      index_range << index_char
+                    end
+                    %>
                     <%index_range.each do |letter| %>
                       <li>
                         <a href="?begins_with=<%=letter %>"
-                             <% if letter == search_char %>
-                              class ="selected-index"<% end %>>
+                           <% if letter == search_char %>
+                           class ="selected-index"<% end %>>
                           <%=letter %>
                         </a>
                       </li>
                     <%end %>
+                    <li>
+                      <a href="?begins_with=%23"
+                         <% if search_char == '#'%>
+                         class ="selected-index"<% end %>>
+                        #
+                      </a>
+                    </li>
                   </ul>
                 </ul>
               </div>
 
-              <%
-                col_count = 0
+              <% col_count = 0
                  @results.records.each do |result|
-                   if result['json']['names'][0]['primary_name'].upcase.start_with?(search_char.upcase)
+                   if (!(search_char =='#') && result.display_string.upcase.start_with?(search_char.upcase)) || !(result.display_string.upcase.start_with?(*index_range)) && (search_char == '#')
                      if col_count % 3 == 0 %>
                     </div>
                     <div class="row matrix-gutter">
@@ -45,8 +56,8 @@
                     end %>
                 <!-- .row -->
               <% end %>
-            </div>
-          </div>
+              </div>
+              </div>
           <!-- .container -->
         </section>
       </main>

--- a/public/views/search/resources_search_results.html.erb
+++ b/public/views/search/resources_search_results.html.erb
@@ -1,0 +1,73 @@
+<% results_type = (defined?(@results_type) ? @results_type : t('search_results.results')) %>
+<%subjects_info=Array.new %>
+<%names_info=Hash.new %>
+<%type_info = Hash.new %>
+<div class="row">
+  <div class="col-sm-12">
+    <%= render partial: 'shared/breadcrumbs' %>
+  </div>
+</div>
+<% if defined?(@results) %>
+  <div class="row" style = "display: none">
+    <div class="col-sm-9">
+      <a name="main" title="<%= t('internal_links.main') %>"></a>
+        <%= render partial: 'shared/sorter' %>
+    </div>
+  </div>
+
+        <main id="skip-header-target" role="main">
+          <section class="py-3">
+            <div class="container" >
+              <h2><%=@results['total_hits']%>
+                <% if @results['total_hits'] ==1 %>
+                 Collection
+                  <%else %>
+                  Collections
+                  <% end %>
+              </h2>
+              <div class="row matrix-gutter">
+                <div class="col-lg-8 mr-3">
+                  <table class="table">
+                    <thead>
+                      <tr id="collection_header">
+                        <th scope="col" id="collection_title" >Collection Title &nbsp<span  class="fa fa-lg fa-caret-up"></span></th>
+                        <th scope="col" id="collection_year">Dates &nbsp<span class="fa fa-lg fa-caret-up"></span></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <% @results.records.each do |result|
+                        subjects_info += result['json']['subjects']%>
+                        <%= render partial: 'landing/resources/resources_result', locals: {:result => result, :props => (@result_props || {}).merge({:full => false})} %>
+                      <% end %>
+                    </tbody>
+                  </table>
+<!--                  Extracting names and their types and storing them as hash-->
+                  <%@results.records.each do |result|
+                    result['json']['linked_agents'].each do |linked_agent|
+                      linked_agent['_resolved']['names'].each do |name|
+                        name.to_json
+                        names_info[name['sort_name']]=name['jsonmodel_type']
+                      end
+                    end
+                  end%>
+
+<!--                  Extracting subjects and their types and storing them as hash-->
+                  <%subjects_info.each do |subject_info|
+                      subject_info['_resolved']['terms'].each do |term_info|
+                        type_info[term_info['term']] = term_info['term_type']
+                      end
+                  end%>
+                </div>
+<!--            Merging name and subject hashes -->
+                <%type_info =type_info.merge(names_info) %>
+                <div class="col-lg-3 ml-2 ">
+                  <h2 class="h4">Filter by:</h2>
+                  <div class="bg-light p-3">
+                  <%= render partial: 'landing/resources/only_facets', locals:{:type_info=>type_info} %>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </main>
+<% end %>

--- a/public/views/shared/_sorter.html.erb
+++ b/public/views/shared/_sorter.html.erb
@@ -1,0 +1,13 @@
+
+<% if defined?(@sort) && defined?(@sort_opts) && defined?(@base_search) %>
+
+
+<div class="col-sm-4 text-right sorter">
+ <%= form_tag(app_prefix("#{@base_search}"), method: 'get', :class=> "form-horizontal",:id => 'sort_form') do %>
+   <%= render partial: 'shared/hidden_params' %>
+   <%= label_tag(:sort, "#{t('search_sorting.sort_by')}", :class=>'sr-only') %>
+   <%= select_tag(:sort, options_for_select(@sort_opts,@sort)) %>
+   <%= submit_tag(t('search_sorting.sort'), :class=>'btn btn-primary btn-sm') %>
+ <% end %>
+</div>
+<% end %>


### PR DESCRIPTION
- Update design according to nyc-core-framework
- Added sorting by Collection title and Dates
- Split 'Filter by' subjects and names into respective subtypes
- Changed 'Filter by' listing order to alphabetic