### PR TITLE
AB#10 - Individual Collection page redesign

### DIFF
--- a/public/assets/javascripts/largetree.js.erb
+++ b/public/assets/javascripts/largetree.js.erb
@@ -1,0 +1,961 @@
+// Local
+(function (exports) {
+    "use strict";
+
+    /************************************************************************/
+    /* Tree ID helpers  */
+    /************************************************************************/
+    var TreeIds = {}
+
+    TreeIds.uri_to_tree_id = function (uri) {
+        var parts = TreeIds.uri_to_parts(uri);
+        return parts.type + '_' + parts.id;
+    }
+
+    TreeIds.uri_to_parts = function (uri) {
+        var last_part = uri.replace(/\/repositories\/[0-9]+\//,"");
+        var bits = last_part.match(/([a-z_]+)\/([0-9]+)/);
+        var type_plural = bits[1].replace(/\//g,'_');
+        var id = bits[2];
+        var type = type_plural.replace(/s$/, '');
+
+        return {
+            type: type,
+            id: id
+        };
+    }
+
+    TreeIds.backend_uri_to_frontend_uri = function (uri) {
+        return AS.app_prefix(uri.replace(/\/repositories\/[0-9]+\//, ""))
+    }
+
+    TreeIds.parse_tree_id = function (tree_id) {
+        var regex_match = tree_id.match(/([a-z_]+)([0-9]+)/);
+        if (regex_match == null || regex_match.length != 3) {
+            return;
+        }
+
+        var row_type = regex_match[1].replace(/_$/, "");
+        var row_id = regex_match[2];
+
+        return {type: row_type, id: row_id}
+    }
+
+    TreeIds.link_url = function(uri) {
+        // convert the uri into tree-speak
+        return uri;
+    };
+
+    exports.TreeIds = TreeIds
+    /************************************************************************/
+
+
+    var SCROLL_DELAY_MS = 100;
+    var THRESHOLD_EMS = 300;
+
+    function LargeTree(datasource, container, root_uri, read_only, renderer, tree_loaded_callback, node_selected_callback) {
+        this.source = datasource;
+        this.elt = container;
+        this.scrollTimer = undefined;
+        this.renderer = renderer;
+
+        this.progressIndicator = $('<progress class="largetree-progress-indicator" />');
+        this.elt.before(this.progressIndicator);
+
+//        this.elt.css('will-change', 'transform');
+
+        this.root_uri = root_uri;
+        this.root_tree_id = TreeIds.uri_to_tree_id(root_uri);
+
+        // default to the root_id
+        this.current_tree_id = this.root_tree_id;
+
+        this.read_only = read_only;
+
+        this.waypoints = {};
+
+        this.node_selected_callback = node_selected_callback;
+        this.populateWaypointHooks = [];
+        this.collapseNodeHooks = [];
+
+        this.errorHandler = $.noop;
+
+        this.initEventHandlers();
+        this.renderRoot(function () {
+            tree_loaded_callback();
+        });
+    }
+
+    LargeTree.prototype.setGeneralErrorHandler = function (callback) {
+        this.errorHandler = callback;
+    };
+
+    LargeTree.prototype.currentlyLoading = function () {
+        this.progressIndicator.css('visibility', 'visible');
+    }
+
+    LargeTree.prototype.doneLoading = function () {
+        var self = this;
+        setTimeout(function () {
+            self.progressIndicator.css('visibility', 'hidden');
+        }, 0);
+    }
+
+
+    LargeTree.prototype.addPlugin = function (plugin) {
+        plugin.initialize(this);
+
+        return plugin;
+    };
+
+    LargeTree.prototype.addPopulateWaypointHook = function (callback) {
+        this.populateWaypointHooks.push(callback);
+    };
+
+    LargeTree.prototype.addCollapseNodeHook = function (callback) {
+        this.collapseNodeHooks.push(callback);
+    };
+
+    LargeTree.prototype.displayNode = function (tree_id, done_callback) {
+        var self = this;
+
+        var node_id = TreeIds.parse_tree_id(tree_id).id;
+
+        var displaySelectedNode = function () {
+            var node = $('#' + tree_id);
+
+            if (done_callback) {
+                done_callback(node);
+            }
+        };
+
+        if (tree_id === self.root_tree_id) {
+            /* We don't need to do any fetching for the root node. */
+            displaySelectedNode();
+        } else {
+            self.source.fetchPathFromRoot(node_id).done(function (paths) {
+                self.recursivelyPopulateWaypoints(paths[node_id], displaySelectedNode);
+            });
+        }
+    };
+
+    LargeTree.prototype.reparentNodes = function (new_parent, nodes, position) {
+        var self = this;
+
+        if (!self.isReparentAllowed(nodes, new_parent)) {
+            // This move is not allowed!
+            // alert user
+            AS.openQuickModal("<%= I18n.t('largetree.reparent_error.title') %>",
+                              "<%= I18n.t('largetree.reparent_error.message') %>")
+
+            return {
+                'done' : $.noop
+            };
+        }
+
+        var scrollPosition = self.elt.scrollTop();
+        var loadingMask = self.displayLoadingMask(scrollPosition)
+
+        var parent_uri = new_parent.data('uri');
+
+        if (!parent_uri) {
+            parent_uri = this.root_uri;
+        }
+
+        if (position) {
+            /* If any of the nodes we're moving were originally siblings that
+            fall before the drop target, we need to adjust the position for the
+            fact that everything will "shift up" when they're moved */
+            var positionAdjustment = 0;
+
+            $(nodes).each(function (idx, elt) {
+                var level = $(elt).data('level');
+                var node_parent_uri = $(elt).prevAll('.indent-level-' + (level - 1) + ':first').data('uri');
+
+                if (!node_parent_uri) {
+                    node_parent_uri = self.root_uri;
+                }
+
+                if (node_parent_uri == parent_uri && $(elt).data('position') < position) {
+                    positionAdjustment += 1;
+                }
+            });
+
+            position -= positionAdjustment;
+        } else {
+            position = 0;
+        }
+
+        /* Record some information about the current state of the tree so we can
+           revert things to more-or-less how they were once we reload. */
+        var uris_to_reopen = [];
+
+
+        /* Refresh the drop target */
+        if (new_parent.data('uri') && !new_parent.is('.root-row')) {
+            uris_to_reopen.push(new_parent.data('uri'));
+        }
+
+        /* Reopen the parent of any nodes we dragged from */
+        $(nodes).each(function (idx, elt) {
+            var level = $(elt).data('level');
+            var parent_uri = $(elt).prevAll('.indent-level-' + (level - 1) + ':first').data('uri');
+
+            if (parent_uri) {
+                uris_to_reopen.push(parent_uri);
+            } else {
+                /* parent was root node */
+            }
+        });
+
+        /* Reopen any other nodes that were open */
+        self.elt.find('.expandme .expanded').closest('tr').each(function (idx, elt) {
+            uris_to_reopen.push($(elt).data('uri'));
+        });
+
+        var uris_to_move = [];
+        $(nodes).each(function (_, elt) {
+            uris_to_move.push($(elt).data('uri'));
+        });
+
+        return this.source.reparentNodes(parent_uri,
+                                         uris_to_move,
+                                         position)
+            .done(function () {
+                self.redisplayAndShow(uris_to_reopen, function () {
+                    self.considerPopulatingWaypoint(function () {
+                        self.elt.animate({
+                            scrollTop: scrollPosition
+                        }, function(){
+                            loadingMask.remove();
+                        });
+
+                        $(nodes).each(function (i, node) {
+                            var id = $(node).attr('id');
+                            self.elt.find('#' + id).addClass('reparented-highlight');
+
+                            setTimeout(function () {
+                                self.elt.find('#' + id).removeClass('reparented-highlight').addClass('reparented');
+                            }, 500);
+                        });
+                    });
+                });
+            });
+    };
+
+    LargeTree.prototype.displayLoadingMask = function (scrollPosition) {
+        var self = this;
+
+        var loadingMask = self.elt.clone(false);
+
+        loadingMask.on('click', function (e) { e.preventDefault(); return false; });
+
+        loadingMask.find('*').removeAttr('id');
+        loadingMask.attr('id', 'tree-container-loading');
+        loadingMask.css('z-index', 2000)
+                   .css('position', 'absolute')
+                   .css('left', self.elt.offset().left)
+                   .css('top', self.elt.offset().top);
+
+        loadingMask.width(self.elt.width());
+
+        var spinner = $('<div class="spinner" />');
+        spinner.css('font-size', '50px')
+               .css('display', 'inline')
+               .css('z-index', 2500)
+               .css('position', 'fixed')
+               .css('margin', 0)
+               .css('left', '50%')
+               .css('top', '50%');
+
+
+        $('body').prepend(loadingMask);
+        $('body').prepend(spinner);
+
+        loadingMask.scrollTop(scrollPosition);
+
+        return {
+            remove: function () {
+                loadingMask.remove();
+                spinner.remove();
+            }
+        };
+    };
+
+    LargeTree.prototype.redisplayAndShow = function(uris, done_callback) {
+        var self = this;
+
+        uris = $.unique(uris);
+
+        if (!done_callback) {
+            done_callback = $.noop;
+        }
+
+        self.renderRoot(function () {
+            var uris_to_reopen = uris.slice(0)
+            var displayedNodes = [];
+
+            var handle_next_uri = function (node) {
+                if (node) {
+                    displayedNodes.push(node);
+                }
+
+                if (uris_to_reopen.length == 0) {
+                    /* Finally, expand any nodes that haven't been expanded along the way */
+                    var expand_next = function (done_callback) {
+                        if (displayedNodes.length > 0) {
+                            var node = displayedNodes.shift();
+                            if (node.is('.root-row')) {
+                                done_callback();
+                            } else {
+                                self.expandNode(node, function () {
+                                    expand_next(done_callback);
+                                });
+                            }
+                        } else {
+                            done_callback();
+                        }
+                    };
+
+                    return expand_next(function () {
+                        return done_callback();
+                    });
+                }
+
+                var uri = uris_to_reopen.shift();
+                var tree_id = TreeIds.uri_to_tree_id(uri);
+
+                self.displayNode(tree_id, handle_next_uri);
+            };
+
+            handle_next_uri();
+        });
+    };
+
+    LargeTree.prototype.recursivelyPopulateWaypoints = function (path, done_callback) {
+        var self = this;
+
+        /*
+           Here, `path` is a list of objects like:
+
+             node: /some/uri; offset: NN
+
+           which means "expand subtree /some/uri then populate waypoint NN".
+
+           The top-level is special because we automatically show it as expanded, so we skip expanding the root node.
+         */
+
+        if (!path || path.length === 0) {
+            done_callback();
+            return;
+        }
+
+        var waypoint_description = path.shift();
+
+        var next_fn = function () {
+            if (!self.waypoints[waypoint_description.node]) {
+                /* An error occurred while expanding. */
+                debugger;
+                return;
+            }
+
+            var waypoint = self.waypoints[waypoint_description.node][waypoint_description.offset];
+
+            if (!waypoint) {
+                /* An error occurred while expanding. */
+                debugger;
+                return;
+            }
+
+            self.populateWaypoint(waypoint, function () {
+                self.recursivelyPopulateWaypoints(path, done_callback);
+            });
+        };
+
+        if (waypoint_description.node) {
+            var tree_id = TreeIds.uri_to_tree_id(waypoint_description.node);
+
+            if ($('#' + tree_id).find('.expandme').find('.expanded').length > 0) {
+                next_fn();
+            } else {
+                self.toggleNode($('#' + tree_id).find('.expandme'), next_fn);
+            }
+        } else {
+            /* this is the root node (subtree already expanded) */
+            next_fn();
+        }
+    };
+
+    LargeTree.prototype.deleteWaypoints = function (parent) {
+        var waypoint = parent.next();
+
+        if (!waypoint.hasClass('waypoint')) {
+            /* Nothing left to burn */
+            return false;
+        }
+
+        if (!waypoint.hasClass('populated')) {
+            waypoint.remove();
+
+            return true;
+        }
+
+        var waypointLevel = waypoint.data('level');
+
+        if (!waypointLevel) {
+            return false;
+        }
+
+        /* Delete all elements up to and including the end waypoint marker */
+        while (true) {
+            var elt = waypoint.next();
+
+            if (elt.length === 0) {
+                break;
+            }
+
+            if (elt.hasClass('end-marker') && waypointLevel == elt.data('level')) {
+                elt.remove();
+                break;
+            } else {
+                elt.remove();
+            }
+        }
+
+        waypoint.remove();
+
+        return true;
+    };
+
+    LargeTree.prototype.toggleNode = function (button, done_callback) {
+        var self = this;
+        var parent = button.closest('tr');
+
+        if (button.data('expanded')) {
+            self.collapseNode(parent, done_callback);
+        } else {
+            self.expandNode(parent, done_callback);
+        }
+    };
+
+    LargeTree.prototype.expandNode = function (row, done_callback) {
+        var self = this;
+        var button = row.find('.expandme');
+
+        if (button.data('expanded')) {
+            if (done_callback) {
+                done_callback();
+            }
+            return;
+        }
+
+        button.find('.expandme-icon').addClass('expanded');
+        $(button).data('expanded', true);
+
+        if (!row.data('uri')) {
+            debugger;
+        }
+
+        self.source.fetchNode(row.data('uri'))
+            .done(function (node) {
+                self.appendWaypoints(row, row.data('uri'), node.waypoints, node.waypoint_size, row.data('level') + 1);
+
+                if (done_callback) {
+                    done_callback();
+                }
+            })
+            .fail(function () {
+                self.errorHandler.apply(self, ['fetch_node_failed'].concat([].slice.call(arguments)));
+            });
+    };
+
+    LargeTree.prototype.collapseNode = function (row, done_callback) {
+        var self = this;
+
+        while (self.deleteWaypoints(row)) {
+            /* Remove the elements from one or more waypoints */
+        }
+
+        var button = row.find('.expandme');
+
+        $(button).data('expanded', false);
+        button.find('.expandme-icon').removeClass('expanded');
+
+        /* Removing elements might have scrolled something else into view */
+        setTimeout(function () {
+            self.considerPopulatingWaypoint();
+        }, 0);
+
+        $(self.collapseNodeHooks).each(function (idx, hook) {
+            hook();
+        });
+
+        if (done_callback) {
+            done_callback();
+        }
+    };
+
+    LargeTree.prototype.initEventHandlers = function () {
+        var self = this;
+        var currentlyExpanding = false;
+
+        /* Content loading */
+        this.elt.on('scroll', function (event) {
+            if (self.scrollTimer) {
+                clearTimeout(self.scrollTimer);
+            }
+
+            var handleScroll = function () {
+                if (!currentlyExpanding) {
+                    currentlyExpanding = true;
+
+                    self.considerPopulatingWaypoint(function () {
+                        currentlyExpanding = false;
+                    });
+                }
+            };
+
+            self.scrollTimer = setTimeout(handleScroll, SCROLL_DELAY_MS);
+        });
+
+        /* Expand/collapse nodes */
+        $(this.elt).on('click', '.expandme', function (e) {
+            e.preventDefault();
+            self.toggleNode($(this));
+        });
+    };
+
+    LargeTree.prototype.makeWaypoint = function (uri, offset, indentLevel) {
+        var result = $('<tr class="waypoint" />');
+        result.addClass('indent-level-' + indentLevel);
+
+        result.data('level', indentLevel);
+        result.data('uri', uri);
+        result.data('offset', offset);
+
+        if (!this.waypoints[uri]) {
+            this.waypoints[uri] = {};
+        }
+
+        /* Keep a lookup table of waypoints so we can find and populate them programmatically */
+        this.waypoints[uri][offset] = result;
+
+        return result;
+    };
+
+    LargeTree.prototype.appendWaypoints = function (elt, parentURI, waypointCount, waypointSize, indentLevel) {
+        var child_count = elt.data('child_count');
+        for (var i = waypointCount - 1; i >= 0; i--) {
+            var waypoint = this.makeWaypoint(parentURI, i, indentLevel);
+
+            waypoint.data('child_count_at_this_level', child_count);
+
+            /* We force the line height to a constant 2em so we can predictably
+               guess how tall to make waypoints.  See largetree.less for where we
+               set this on table.td elements. */
+            //waypoint.css('height', 2 + 'em');
+            elt.after(waypoint);
+        }
+
+        var self = this;
+        setTimeout(function () {self.considerPopulatingWaypoint(); }, 0);
+    };
+
+    LargeTree.prototype.renderRoot = function (done_callback) {
+        var self = this;
+        self.waypoints = {};
+
+        var rootList = $('<table class="root pt-2 pb-2" />');
+
+        this.source.fetchRootNode().done(function (rootNode) {
+            var row = self.renderer.get_root_template();
+
+            row.data('uri', rootNode.uri);
+            row.attr('id', TreeIds.uri_to_tree_id(rootNode.uri));
+            row.addClass('root-row');
+            row.data('level', 0);
+            row.data('child_count', rootNode.child_count);
+            row.data('jsonmodel_type', rootNode.jsonmodel_type);
+            row.find('.title').append($('<p>')
+                                              .addClass('record-title description')
+                                              .text(rootNode.title));
+
+            rootList.append(row);
+            self.appendWaypoints(row, null, rootNode.waypoints, rootNode.waypoint_size, 1);
+
+            /* Remove any existing table */
+            self.elt.find('table.root').remove();
+
+            self.elt.prepend(rootList);
+            self.renderer.add_root_columns(row, rootNode);
+            if (done_callback) {
+                done_callback();
+            }
+        });
+    };
+
+    LargeTree.prototype.considerPopulatingWaypoint = function (done_callback) {
+        var self = this;
+
+        if (!done_callback) {
+            done_callback = $.noop;
+        }
+
+        var emHeight = parseFloat($("body").css("font-size"));
+        var threshold_px = emHeight * THRESHOLD_EMS;
+        var containerTop = this.elt.offset().top;
+        var containerHeight = this.elt.outerHeight();
+
+        /* Pick a reasonable guess at which waypoint we might want to populate
+           (based on our scroll position) */
+        var allWaypoints = self.elt.find('.waypoint');
+
+        if (allWaypoints.length == 0) {
+            done_callback();
+            return;
+        }
+
+        var scrollPercent = self.elt.scrollTop() / self.elt.find('table.root').height();
+        var startIdx = Math.floor(scrollPercent * allWaypoints.length);
+
+        var waypointToPopulate;
+        var evaluateWaypointFn = function (elt) {
+            /* The element's top is measured from the top of the page, but we
+               want it relative to the top of the container.  Adjust as
+               appropriate. */
+            var eltTop = elt.offset().top - containerTop;
+            var eltBottom = eltTop + elt.height();
+
+            var waypointVisible = (Math.abs(eltTop) <= (containerHeight + threshold_px)) ||
+                                  (Math.abs(eltBottom) <= (containerHeight + threshold_px)) ||
+                                  (eltTop < 0 && eltBottom > 0);
+
+            if (waypointVisible) {
+                var candidate = {
+                    elt: elt,
+                    top: eltTop,
+                    level: elt.data('level'),
+                };
+
+                if (!waypointToPopulate) {
+                    waypointToPopulate = candidate;
+                } else {
+                    if (waypointToPopulate.level > candidate.level || waypointToPopulate.top > candidate.top) {
+                        waypointToPopulate = candidate;
+                    }
+                }
+
+                return true;
+            } else {
+                return false;
+            }
+        };
+
+        /* Search for a waypoint by scanning backwards */
+        for (var i = startIdx; i >= 0; i--) {
+            var waypoint = $(allWaypoints[i]);
+
+            if (waypoint.hasClass('populated')) {
+                /* nothing to do for this one */
+                continue;
+            }
+
+            var waypointWasVisible = evaluateWaypointFn(waypoint);
+
+            if (!waypointWasVisible && i < startIdx) {
+                /* No point considering waypoints even further up in the DOM */
+                break;
+            }
+        }
+
+        /* Now scan forwards */
+        for (var i = startIdx + 1; i < allWaypoints.length; i++) {
+            var waypoint = $(allWaypoints[i]);
+
+            if (waypoint.hasClass('populated')) {
+                /* nothing to do for this one */
+                continue;
+            }
+
+            var waypointWasVisible = evaluateWaypointFn(waypoint);
+
+            if (!waypointWasVisible) {
+                /* No point considering waypoints even further up in the DOM */
+                break;
+            }
+        }
+
+        if (waypointToPopulate) {
+            self.currentlyLoading();
+            self.populateWaypoint(waypointToPopulate.elt, function () {
+                setTimeout(function () {
+                    self.considerPopulatingWaypoint(done_callback);
+                }, 0);
+            });
+        } else {
+            self.doneLoading();
+            done_callback();
+        }
+    };
+
+    var activeWaypointPopulates = {};
+
+    LargeTree.prototype.populateWaypoint = function (elt, done_callback) {
+        if (elt.hasClass('populated')) {
+            done_callback();
+            return;
+        }
+
+        var self = this;
+        var uri = elt.data('uri');
+        var offset = elt.data('offset');
+        var level = elt.data('level');
+
+        var key = uri + "_" + offset;
+        if (activeWaypointPopulates[key]) {
+            return;
+        }
+
+        activeWaypointPopulates[key] = true;
+
+        this.source.fetchWaypoint(uri, offset).done(function (nodes) {
+            var endMarker = self.renderer.endpoint_marker();
+            endMarker.data('level', level);
+            endMarker.data('child_count_at_this_level', elt.data('child_count_at_this_level'));
+            endMarker.addClass('indent-level-' + level);
+
+            elt.after(endMarker);
+
+            var newRows = [];
+            var current = undefined;
+
+            $(nodes).each(function (idx, node) {
+                var row = self.renderer.get_node_template();
+
+                row.addClass('largetree-node indent-level-' + level);
+                row.css('color','#181A7B');
+                row.data('level', level);
+                row.data('child_count', node.child_count);
+                row.css('height','auto')
+                var title = row.find('.title');
+                var strippedTitle = $("<div>").html(node.title).text();
+                title.append($('<a class="record-title" />').prop('href', TreeIds.link_url(node.uri)).text(node.title));
+                title.attr('title', strippedTitle);
+
+                var ex = row.find('.expandme');
+                ex.attr('aria-label', 'expand element');
+                if (node.child_count === 0) {
+//                    ex.css('visibility', 'hidden');
+                    row.css('color','black');
+                    ex.attr('aria-hidden', 'true');
+                    ex.css('padding-left','10px');
+                }
+
+                self.renderer.add_node_columns(row, node);
+
+                var tree_id = TreeIds.uri_to_tree_id(node.uri);
+
+                row.data('uri', node.uri);
+                row.data('jsonmodel_type', node.jsonmodel_type);
+                row.data('position', node.position);
+                row.data('parent_id', node.parent_id);
+                row.attr('id', tree_id);
+
+                if (self.current_tree_id == tree_id) {
+                    row.addClass('current');
+                    current = row;
+                } else {
+                    row.removeClass('current');
+                }
+
+                newRows.push(row);
+            });
+
+            elt.after.apply(elt, newRows);
+
+            elt.addClass('populated');
+
+            activeWaypointPopulates[key] = false;
+
+            $(self.populateWaypointHooks).each(function (idx, hook) {
+                hook();
+            });
+
+            if (current) {
+                $.proxy(self.node_selected_callback, self)(current, self);
+            }
+
+            done_callback();
+        });
+    };
+
+    /*********************************************************************************/
+    /* Data source */
+    /*********************************************************************************/
+    function TreeDataSource(baseURL) {
+        this.url = baseURL.replace(/\/+$/, "");
+    }
+
+
+    TreeDataSource.prototype.urlFor = function (action) {
+        return this.url + "/" + action;
+    };
+
+    TreeDataSource.prototype.fetchRootNode = function () {
+        var self = this;
+
+        return $.ajax(this.urlFor("root"),
+                      {
+                          method: "GET",
+                          dataType: 'json',
+                      })
+                .done(function (rootNode) {
+                    self.cachePrecomputedWaypoints(rootNode);
+                });
+    };
+
+    TreeDataSource.prototype.fetchNode = function (uri) {
+        var self = this;
+
+        if (!uri) {
+            throw "Node can't be empty!";
+        }
+
+        return $.ajax(this.urlFor("node"),
+                      {
+                          method: "GET",
+                          dataType: 'json',
+                          data: {
+                              /* THINKME: Should rename node to node_uri?  S */
+                              node: uri,
+                          }
+                      })
+                .done(function (node) {
+                    self.cachePrecomputedWaypoints(node);
+                });
+    };
+
+    TreeDataSource.prototype.fetchPathFromRoot = function (node_id) {
+        var self = this;
+
+        return $.ajax(this.urlFor("node_from_root"),
+                      {
+                          method: "GET",
+                          dataType: 'json',
+                          data: {
+                              node_ids: [node_id],
+                          }
+                      });
+    };
+
+    TreeDataSource.prototype.fetchWaypoint = function (uri, offset) {
+        var cached = this.getPrecomputedWaypoint(uri, offset);
+
+        if (cached) {
+            return {
+                done: function (callback) {
+                    callback(cached);
+                }
+            };
+        } else {
+            return $.ajax(this.urlFor("waypoint"),
+                          {
+                              method: "GET",
+                              dataType: 'json',
+                              data: {
+                                  node: uri,
+                                  offset: offset,
+                              }
+                          });
+        }
+    };
+
+    TreeDataSource.prototype.reparentNodes = function (new_parent_uri, node_uris, position) {
+        var target = TreeIds.backend_uri_to_frontend_uri(new_parent_uri);
+
+        return $.ajax(target + "/accept_children",
+               {
+                   method: 'POST',
+                   data: {
+                       children: node_uris,
+                       index: position,
+                   }
+               });
+    };
+
+    var precomputedWaypoints = {};
+
+    TreeDataSource.prototype.getPrecomputedWaypoint = function (uri, offset) {
+        var result;
+
+        if (uri === null) {
+            uri = "";
+        }
+
+        if (precomputedWaypoints[uri] && precomputedWaypoints[uri][offset]) {
+            result = precomputedWaypoints[uri][offset];
+            precomputedWaypoints[uri] = {};
+        }
+
+        return result;
+    };
+
+    TreeDataSource.prototype.cachePrecomputedWaypoints = function (node) {
+        $(Object.keys(node.precomputed_waypoints)).each(function (idx, uri) {
+            precomputedWaypoints[uri] = node.precomputed_waypoints[uri];
+        });
+    };
+
+    LargeTree.prototype.setCurrentNode = function(tree_id, callback) {
+        $('#'+this.current_tree_id, this.elt).removeClass('current');
+        this.current_tree_id = tree_id;
+
+        if ($('#'+this.current_tree_id, this.elt).length == 1) {
+            var current = $('#'+this.current_tree_id, this.elt);
+            current.addClass('current');
+            $.proxy(this.node_selected_callback, self)(current, this);
+            if (callback) {
+                callback();
+            }
+        } else {
+            this.displayNode(this.current_tree_id, callback);
+        }
+    };
+
+    LargeTree.prototype.isReparentAllowed = function(nodes_to_move, target_node) {
+        var self = this;
+
+        if (target_node.is('.root-row')) {
+            // always able to drop onto root node
+            return true;
+        }
+
+        var uris_to_check = [];
+        uris_to_check.push(target_node.data('uri'));
+        var level = target_node.data('level') - 1;
+        var row = target_node;
+        while (level > 0) {
+            row = row.prevAll('.largetree-node.indent-level-' + level + ':first');
+            uris_to_check.push(row.data('uri'));
+            level -= 1;
+        }
+
+        var isAllowed = true;
+
+        $(nodes_to_move).each(function (idx, selectedRow) {
+            var uri = $(selectedRow).data('uri');
+            if ($.inArray(uri, uris_to_check) >= 0) {
+                isAllowed = false;
+                return;
+            }
+        });
+
+        return isAllowed;
+
+    };
+
+
+    exports.LargeTree = LargeTree;
+    exports.TreeDataSource = TreeDataSource;
+
+}(window));

--- a/public/assets/javascripts/tree_renderer.js.erb
+++ b/public/assets/javascripts/tree_renderer.js.erb
@@ -1,0 +1,116 @@
+(function(exports) {
+
+    function SimpleRenderer(should_link_to_record) {
+        this.endpointMarkerTemplate = $('<tr class="end-marker" />');
+
+        this.should_link_to_record = should_link_to_record || false;
+
+        this.rootTemplate = $('<tr> ' +
+            '  <td class="no-drag-handle"></td>' +
+            '  <td class="title"></td>' +
+            '</tr>');
+
+
+        this.nodeTemplate = $('<tr> ' +
+            '  <td class="drag-handle"></td>' +
+            '  <td class="title"><span class="indentor"><span class="expandme fa fa-chevron-right" /></span> </td>' +
+            '</tr>');
+    }
+
+
+    SimpleRenderer.prototype.endpoint_marker = function () {
+        return this.endpointMarkerTemplate.clone(true);
+    }
+
+
+    SimpleRenderer.prototype.get_root_template = function () {
+        return this.rootTemplate.clone(false);
+    }
+
+
+    SimpleRenderer.prototype.get_node_template = function () {
+        return this.nodeTemplate.clone(false);
+    };
+
+
+    SimpleRenderer.prototype.add_root_columns = function (row, rootNode) {
+        var $link = row.find('a.record-title');
+
+        if (this.should_link_to_record) {
+            if(rootNode.slugged_url && rootNode.slugged_url.length > 0) {
+                $link.attr('href', rootNode.slugged_url);
+            }
+            else {
+                $link.attr('href', AS.app_prefix(rootNode.uri));
+            }
+        }
+
+        $link.html(rootNode.parsed_title);
+
+        if (rootNode.jsonmodel_type == 'classification') {
+            $link.prepend(rootNode.identifier + '<%= I18n.t('classification.identifier_separator') %> ');
+        }
+    }
+
+
+    SimpleRenderer.prototype.add_node_columns = function (row, node) {
+        var $link = row.find('a.record-title');
+
+        if (node.jsonmodel_type == 'classification_term') {
+            $link.html(node.parsed_title);
+            $link.prepend(node.identifier + '<%= I18n.t('classification.identifier_separator') %> ');
+        } else {
+            var title = this.build_node_title(node);
+            $link.html(title);
+        }
+
+        if (this.should_link_to_record) {
+            if(node.slugged_url && node.slugged_url.length > 0) {
+                $link.attr('href', node.slugged_url);
+            }
+            else {
+                $link.attr('href', AS.app_prefix(node.uri));
+            }
+        }
+    };
+
+
+    SimpleRenderer.prototype.build_node_title = function (node) {
+        var title_bits = [];
+        if (node.parsed_title) {
+            title_bits.push(node.parsed_title);
+        }
+
+        if (node.label) {
+            title_bits.push(node.label);
+        }
+
+        if (node.dates && node.dates.length > 0) {
+          node.dates.forEach(function(date) {
+            if (date.expression) {
+              if (date.type === 'bulk') {
+                title_bits.push('<%= I18n.t("date_type_bulk.bulk") %>: ' + date.expression);
+              } else {
+                title_bits.push(date.expression);
+              }
+            } else if (date.begin && date.end) {
+              if (date.type === 'bulk') {
+                title_bits.push('<%= I18n.t("date_type_bulk.bulk") %>: ' + date.begin + '-' + date.end);
+              } else {
+                title_bits.push(date.begin + '-' + date.end);
+              };
+            } else if (date.begin) {
+              if (date.type === 'bulk') {
+                title_bits.push('<%= I18n.t("date_type_bulk.bulk") %>: ' + date.begin);
+              } else {
+                title_bits.push(date.begin);
+              };
+            }
+          })
+        }
+
+        return title_bits.join(', ');
+    }
+
+    exports.SimpleRenderer = SimpleRenderer;
+})(window);

--- a/public/views/resources/_agents_list.html.erb
+++ b/public/views/resources/_agents_list.html.erb
@@ -1,0 +1,21 @@
+<% list.each do |role, relationships| %>
+
+  <h4 class="pt-1"><%= I18n.t("enumerations.linked_agent_role.#{role}", :default => role) %></h4>
+  <ul class="present_list agents_list">
+
+    <% relationships.each do |relationship| %>
+      <% agent = relationship.fetch('_resolved') %>
+      <p>
+        <%if agent['jsonmodel_type'] == "agent_corporate_entity"%>
+          <span class="fa fa-university"></span>
+          <%else %>
+          <span class="fa fa-user"></span>
+          <%end %>
+        <% unless relationship['_inherited'].blank? %>
+          <%= inheritance(relationship['_inherited']).html_safe %>
+        <% end %>
+        <%= link_to agent['title'], app_prefix(agent['uri']) %>
+      </p>
+    <% end %>
+  </ul>
+<% end %>

--- a/public/views/resources/_facets.html.erb
+++ b/public/views/resources/_facets.html.erb
@@ -1,0 +1,73 @@
+<%# displaying chosen facet(s) (if any) and facets %>
+
+<div class="filters">
+ <% unless @filters.blank? && @search.filters_blank? %>
+    <h3>Collection Organization</h3>
+       <ul>
+        <% @search.get_filter_q_arr(@page_search).each do |f_q| %>
+	  <% unless f_q['v'].blank? %>
+	   <li class="list-group-item"><span class="filter"><%= t('search_results.search_term') %>: <%= f_q['v'] %>
+	       <a href="<%= app_prefix(f_q['uri']) %>" title="<%= t('search_results.remove_filter')%>" class="delete_filter">X</a></span></li>
+          <% end %>
+        <% end %>
+      <% unless @search[:filter_from_year].blank? && @search[:filter_to_year].blank? %>
+      <%
+	 from_year = (@search[:filter_from_year].blank? ? '' : @search[:filter_from_year] )
+	 to_year = (@search[:filter_to_year].blank? ? t('search_results.filter.year_now') : @search[:filter_to_year])
+      %>
+      <li class="list-group-item"><span class="filter"><%= t('search_results.filter.from_to', {:begin=> from_year, :end => to_year  })%>
+	  <a href="<%= app_prefix(@page_search.sub("&filter_from_year=#{(from_year=='' ? '*' : from_year)}&filter_to_year=#{(to_year==t('search_results.filter.year_now') ? '*' : to_year)}",""))%>"
+	     title="<%= t('search_results.remove_filter') %> " class="delete_filter">X</a>
+      </span></li>
+  <% end  %>
+	<% @filters.each do |k, a| %>
+	  <% a.each do |h| %>
+		  <li class="list-group-item"><span class="filter"><%= h['pt'] %>: <%= h['pv'] %>
+			  <a href="<%= app_prefix(h['uri']) %>"
+					title="<%= t('search_results.remove_filter') %> " class="delete_filter">X</a>
+		  </li>
+	  <% end %>
+	<% end %>
+ </ul>
+ <% end %>
+</div>
+
+<% if @search[:dates_within] || @search[:text_within] %>
+<h3><%= t('search_results.filter.head') %></h3>
+ <div class="filter_more">
+   <%= form_tag(app_prefix("#{@base_search}"), method: 'get', :class=> "form-horizontal") do %>
+        <%= render partial: 'shared/hidden_params', :locals => { :no_ids => true } %>
+        <% if @search[:text_within] %>
+          <div class="form-group">
+            <%= hidden_field_tag('sort', "", :id => nil) %>
+            <%= label_tag('filter_q[]', t('actions.search_within'), :class => 'sr-only') %>
+            <%= text_field_tag('filter_q[]', nil, :id => nil, :placeholder =>  t('actions.search_within'),
+            :class=> "form-control", 'aria-label' => t('actions.search_within')) %>
+          </div>
+        <% end %>
+        <% if @search.search_dates_within? %>
+          <div class="form-group">
+            <div class="col-md-6 year_from">
+              <%= label_tag(:filter_from_year, t('search_results.filter.from_year'), :class => 'sr-only') %>
+              <%= text_field_tag(:filter_from_year, nil, :size => 4,:maxlength => 4,
+              :placeholder => t('search_results.filter.from_year'), :class=>"form-control",
+              :id => nil, 'aria-label' => t('search_results.filter.from_year')) %>
+            </div>
+            <div class="col-md-6 year_to">
+              <%= label_tag(:filter_to_year, t('search_results.filter.to_year'), :class=> 'sr-only') %>
+              <%= text_field_tag(:filter_to_year, nil, :size => 4, :maxlength => 4,
+              :class=> "form-control", :placeholder => t('search_results.filter.to_year'),
+              :id => nil, 'aria-label' => t('search_results.filter.to_year')) %>
+            </div>
+          </div>
+        <% else %>
+          <%= hidden_field_tag(:filter_from_year, @search[:filter_from_year], :id => nil) %>
+          <%= hidden_field_tag(:filter_to_year, @search[:filter_to_year], :id => nil) %>
+        <% end %>
+
+       <%= submit_tag(t('search-button.label'), :class=>'btn btn-primary', :id => nil) %>
+  <% end %>
+ </div>
+
+<% end %>
+<%= render partial: 'shared/only_facets' %>

--- a/public/views/resources/_finding_aid.html.erb
+++ b/public/views/resources/_finding_aid.html.erb
@@ -1,0 +1,34 @@
+<% order = %w(title subtitle status author date description_rules language script language_note sponsor edition_statement series statement) %>
+
+<% unless @result.finding_aid.blank? %>
+  <% if @result.finding_aid.size > 1 || @result.finding_aid['revisions'].blank? %>
+    <dl class="dl-horizontal-fa">
+      <% order.each do |item| %>
+        <% unless @result.finding_aid[item].blank? %>
+          <dt><%= t("resource._public.finding_aid.#{item}") %></dt>
+      	  <dd>
+            <% if item == "status" %>
+              <%= t("resource_finding_aid_status.#{@result.finding_aid[item]}") %>
+            <% elsif item == "language" %>
+              <%= t("enumerations.language_iso639_2.#{@result.finding_aid[item]}") %>
+            <% elsif item == "script" %>
+              <%= t("enumerations.script_iso15924.#{@result.finding_aid[item]}") %>
+            <% elsif item == "description_rules" %>
+              <%= t("enumerations.resource_finding_aid_description_rules.#{@result.finding_aid[item]}") %>
+            <% else %>
+              <%= @result.finding_aid[item] %>
+            <% end %>
+          </dd>
+        <% end %>
+      <% end %>
+    </dl>
+  <% end %>
+  <% unless @result.finding_aid['revision'].blank? %>
+    <h3><%= t('resource._public.finding_aid.revision') %> </h3>
+    <ul>
+    <% @result.finding_aid['revision'].each do |rev| %>
+      <li><em><%= rev['date']%>:</em> <%= rev['desc'] %></li>
+    <% end %>
+    </ul>
+  <% end %>
+<% end %>

--- a/public/views/resources/_idbadge.html.erb
+++ b/public/views/resources/_idbadge.html.erb
@@ -1,0 +1,62 @@
+<%
+if result.level
+    if result.primary_type =~ /digital_object/
+      level = I18n.t("enumerations.digital_object_level.#{result.level}", :default => result.level)
+      badge_label = I18n.t("digital_object._public.badge_label", :level => level)
+    else
+      level = result.level == 'otherlevel' ? result.other_level : result.level
+      badge_label = I18n.t("enumerations.archival_record_level.#{level}", :default => level)
+    end
+else
+    badge_label = t("#{result.primary_type}._singular")
+end
+%>
+
+<%# build URL with slugs depending on the primary type %>
+<% case result.primary_type %>
+  <% when "resource" %>
+    <% url = resource_base_url(result) %>
+  <% when "archival_object" %>
+    <% url = archival_object_base_url(result) %>
+  <% when "digital_object" %>
+    <% url = digital_object_base_url(result) %>
+  <% when "accession" %>
+    <% url = accession_base_url(result) %>
+  <% when "subject" %>
+    <% url = subject_base_url(result) %>
+  <% when "classification" %>
+    <% url = classification_base_url(result) %>
+  <% when "agent_person" %>
+    <% url = agent_base_url(result) %>
+  <% when "agent_family" %>
+    <% url = agent_base_url(result) %>
+  <% when "agent_corporate_entity" %>
+    <% url = agent_base_url(result) %>
+  <% when "agent_software" %>
+    <% url = agent_base_url(result) %>
+  <% else %>
+    <% url = result.uri %>
+<% end %>
+
+<h2>
+  <% if !props.fetch(:full,false) %>
+    <div class="card m-2">
+      <button class="btn btn-md btn-light text-primary">
+        <a href="<%= app_prefix(url) %>">
+          <%== props.fetch(:infinite_item, false) ? result.parse_full_title(true) : result.display_string %>
+        </a>
+      </button>
+    </div>
+  <% else %>
+    <%== result.display_string %>
+    <small><%=t('resource._singular') %> <%= @result.ead_id %></small>
+  <% end %>
+</h2>
+
+<%@result.classifications.each do |c|
+  c.fetch('breadcrumb').each do |crumb, i|
+     crumb_uri = crumb.fetch(:uri)
+       crumb_uri = c.fetch('uri') if crumb_uri.blank? %>
+    <p class="mb-1"><%= link_to crumb.fetch(:crumb), app_prefix(crumb_uri),class: 'description' %></p>
+  <%end
+end %>

--- a/public/views/resources/_infinite_idbadge.html.erb
+++ b/public/views/resources/_infinite_idbadge.html.erb
@@ -1,0 +1,91 @@
+<%
+  if result.level
+    if result.primary_type =~ /digital_object/
+      level = I18n.t("enumerations.digital_object_level.#{result.level}", :default => result.level)
+      badge_label = I18n.t("digital_object._public.badge_label", :level => level)
+    else
+      level = result.level == 'otherlevel' ? result.other_level : result.level
+      badge_label = I18n.t("enumerations.archival_record_level.#{level}", :default => level)
+    end
+  else
+    badge_label = t("#{result.primary_type}._singular")
+  end
+  indent_level = @result.raw.fetch('ancestors', []).length
+%>
+
+<%# build URL with slugs depending on the primary type %>
+<% case result.primary_type %>
+<% when "resource" %>
+  <% url = resource_base_url(result) %>
+<% when "archival_object" %>
+  <% url = archival_object_base_url(result) %>
+<% when "digital_object" %>
+  <% url = digital_object_base_url(result) %>
+<% when "accession" %>
+  <% url = accession_base_url(result) %>
+<% when "subject" %>
+  <% url = subject_base_url(result) %>
+<% when "classification" %>
+  <% url = classification_base_url(result) %>
+<% when "agent_person" %>
+  <% url = agent_base_url(result) %>
+<% when "agent_family" %>
+  <% url = agent_base_url(result) %>
+<% when "agent_corporate_entity" %>
+  <% url = agent_base_url(result) %>
+<% when "agent_software" %>
+  <% url = agent_base_url(result) %>
+<% else %>
+  <% url = result.uri %>
+<% end %>
+
+<% if indent_level == 1%>
+  <hr class="mt-2"/>
+<% end %>
+
+<%if indent_level < 2 %>
+  <h2>
+    <% if !props.fetch(:full,false) %>
+      <h4 class="pt-2 pb-2">
+        <%if indent_level!= 0 %>
+          <% comp_id = display_component_id(result, props.fetch(:infinite_item, false)) %>
+          <% unless comp_id.blank? %>
+            <%= badge_label %> <%=comp_id %> :
+          <% end %>
+        <% end %>
+        <%== props.fetch(:infinite_item, false) ? result.parse_full_title(true) : result.display_string %>
+      </h4>
+
+    <% else %>
+      <%== result.display_string %>
+      <small><%=t('resource._singular') %> <%= @result.ead_id %></small>
+    <% end %>
+  </h2>
+
+<% else %>
+  <h5 class="ml-2">
+    <% if !props.fetch(:full,false) %>
+      <a class="record-title" href="<%= app_prefix(url) %>">
+        <%== props.fetch(:infinite_item, false) ? result.parse_full_title(true) : result.display_string %>
+      </a>
+
+    <% else %>
+      <%== result.display_string %>
+      <small><%=t('resource._singular') %> <%= @result.ead_id %></small>
+    <% end %>
+
+    <div class="badge-and-identifier">
+      <small>
+        <div class="record-type-badge <%= (result.primary_type.start_with?('agent') ? 'agent' : result.primary_type) %>">
+          <i class="<%= icon_for_type(result.primary_type) %>"></i>&#160;<%= badge_label %> <% if result.container_summary_for_badge %> &mdash; <%= result.container_summary_for_badge %><% end %>
+        </div>
+        <% comp_id = display_component_id(result, props.fetch(:infinite_item, false)) %>
+        <% unless comp_id.blank? %>
+          <div class="identifier">
+            <span class="id-label"><%= t('search_sorting.identifier') %>:</span>&#160;<span class="component"><%= comp_id %></span>
+          </div>
+        <% end %>
+      </small>
+    </div>
+  </h5>
+<% end %>

--- a/public/views/resources/_infinite_item.html.erb
+++ b/public/views/resources/_infinite_item.html.erb
@@ -1,0 +1,66 @@
+<%
+  indent_level = @result.raw.fetch('ancestors', []).length
+%>
+<div class="infinite-item infinite-item-indent-<%= indent_level %>">
+  <div class="information">
+      <%=
+        render partial: 'resources/infinite_idbadge', locals: {
+          :props => { :full => false, :infinite_item => true },
+          :result => @result,
+        }
+      %>
+  </div>
+
+  <% scopecontent_note = @result.note('scopecontent') %>
+  <% if scopecontent_note && !inherited?(scopecontent_note) %>
+    <%= render partial: 'shared/single_note', locals: {:type => 'abstract', :note_struct => scopecontent_note, :notitle => true} %>
+  <% end %>
+
+  <% if indent_level < 2 %>
+    <div class="row pt-2">
+      <% unless @result.extents.blank? || all_inherited?(@result.extents) %>
+        <div class="col-lg-9">
+          <h5><%= t('resource._public.extent') %></h5>
+          <% @result.extents.each do |extent| %>
+            <p>
+              <%= inheritance(extent['_inherited']).html_safe %>
+              <%= extent['display']%>
+            </p>
+          <% end %>
+        </div>
+      <% end %>
+
+      <% unless @result.dates.blank? || all_inherited?(@result.dates) %>
+        <div class="col-lg-3">
+          <h5><%= t('resource._public.dates') %></h5>
+            <% @result.dates.each do |date| %>
+            <p>
+              <%= inheritance(date['_inherited']).html_safe %>
+              <%= date['final_expression'] %>
+            </p>
+            <% end %>
+        </div>
+      <% end %>
+    </div>
+  <%end %>
+
+  <div class="row pt-2">
+    <div class="col-lg">
+      <% unless @result.agents.blank? || all_inherited?(@result.agents.collect(&:last).flatten) %>
+        <h5>Creators</h5>
+          <% @result.agents.collect(&:last).flatten.each do |relationship| %>
+            <p>
+              <a href="<%=app_prefix(relationship.fetch('ref'))%>">
+                <span class="fa fa-user"/>
+                <%=relationship.fetch('_resolved').fetch('title')%>
+              </a>
+            </p>
+          <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <%if indent_level==1 %>
+    <h5 class="pb-2">Contents</h5>
+  <%end %>
+</div>

--- a/public/views/resources/_inventory_idbadge.html.erb
+++ b/public/views/resources/_inventory_idbadge.html.erb
@@ -1,0 +1,50 @@
+<%
+  if result.level
+    if result.primary_type =~ /digital_object/
+      level = I18n.t("enumerations.digital_object_level.#{result.level}", :default => result.level)
+      badge_label = I18n.t("digital_object._public.badge_label", :level => level)
+    else
+      level = result.level == 'otherlevel' ? result.other_level : result.level
+      badge_label = I18n.t("enumerations.archival_record_level.#{level}", :default => level)
+    end
+  else
+    badge_label = t("#{result.primary_type}._singular")
+  end
+%>
+
+<%# build URL with slugs depending on the primary type %>
+<% case result.primary_type %>
+<% when "resource" %>
+  <% url = resource_base_url(result) %>
+<% when "archival_object" %>
+  <% url = archival_object_base_url(result) %>
+<% when "digital_object" %>
+  <% url = digital_object_base_url(result) %>
+<% when "accession" %>
+  <% url = accession_base_url(result) %>
+<% when "subject" %>
+  <% url = subject_base_url(result) %>
+<% when "classification" %>
+  <% url = classification_base_url(result) %>
+<% when "agent_person" %>
+  <% url = agent_base_url(result) %>
+<% when "agent_family" %>
+  <% url = agent_base_url(result) %>
+<% when "agent_corporate_entity" %>
+  <% url = agent_base_url(result) %>
+<% when "agent_software" %>
+  <% url = agent_base_url(result) %>
+<% else %>
+  <% url = result.uri %>
+<% end %>
+
+<% if !props.fetch(:full,false) %>
+  <span class="card-title align-middle description">
+    <a href="<%= app_prefix(url) %>">
+      <%== props.fetch(:infinite_item, false) ? result.parse_full_title(true) : result.display_string %>
+    </a>
+  </span>
+
+<% else %>
+  <%== result.display_string %>
+<% end %>

--- a/public/views/resources/_linked_digital_objects.html.erb
+++ b/public/views/resources/_linked_digital_objects.html.erb
@@ -1,0 +1,7 @@
+<ul>
+  <% digital_objects.each do |uri, digital_object| %>
+    <li>
+      <%= link_to digital_object.display_string, app_prefix(uri) %>
+    </li>
+  <% end %>
+</ul>

--- a/public/views/resources/_record_innards.html.erb
+++ b/public/views/resources/_record_innards.html.erb
@@ -1,0 +1,131 @@
+<!-- Look for '_inherited' and '*_inherited' properties -->
+<% non_folder = %w(summary langmaterial accessrestrict userestrict bioghist) %>
+<% folder = %w(abstract arrangement phystech physloc otherfindaid custodhist acqinfo appraisal accruals originalsloc altformavail extent relatedmaterial separatedmaterial note_bibliography materialspec physdesc inscription physfacet dimensions edition fileplan legalstatus odd note processinfo note_index) %>
+<%id_set="" %>
+
+<div class="upper-record-details">
+	<%@result.notes['abstract'].each do |note_struct|
+		if !note_struct['note_text'].blank? %>
+			<div class="note">
+				<h3 class="abstract single_node">Abstract</h3>
+				<%= render  partial: 'shared/single_note',
+										locals: {:type => 'abstract', :note_struct => note_struct,:notitle => true }  %>
+			</div>
+		<% end %>
+	<% end %>
+
+	<div class="row pb-2">
+		<div class="col-lg-6">
+			<% unless @result.extents.blank? %>
+					<h4 class="pt-1"><%= t('resource._public.extent') %></h4>
+					<% @result.extents.each do |ext| %>
+						<p class="extent"><%= inheritance(ext['_inherited']).html_safe %>
+							<%= ext['display']%>
+						</p>
+					<% end %>
+			<% end %>
+		</div>
+		<div class="col-lg-6">
+			<% unless @result.dates.blank? %>
+				<h4 class="pt-1"><%= t('resource._public.dates') %></h4>
+				<%= render partial: 'shared/dates', locals: {:dates => @result.dates} %>
+			<% end %>
+		</div>
+	</div>
+	<hr>
+
+	<div class="row pb-2">
+		<div class="col-lg">
+			<% if @result.agents && Array(@result.agents['creator']).length > 0 %>
+				<% a_direct_creator = @result.agents['creator'].reject{|r| r['_inherited']}%>
+				<% unless a_direct_creator.empty? %>
+					<%= render partial: 'resources/agents_list', locals: {:list => {'creator' => a_direct_creator}} %>
+				<% end %>
+			<% end %>
+		</div>
+	</div>
+	<hr>
+
+	<div class ="pt-2">
+	<% (@result.notes["accessrestrict"] || []).each do |note_struct| %>
+	 <% unless note_struct['note_text'].blank? %>
+		<%= render partial: 'shared/single_note', locals: {:type => "accessrestrict", :note_struct => note_struct,:title_desc => '4'}   %>
+	 <% end %>
+	<% end %>
+	</div>
+
+	<% if @result.is_a?(Accession) && @result.inventory %>
+		<h3><%= t('accession._public.section.inventory') %></h3>
+		<p><%= @result.inventory %></p>
+	<% end %>
+
+	<% ASUtils.find_local_directories('public/views/_upper_record_innards.html.erb').each do |template| %>
+		<%= render :file => template if File.exists?(template) %>
+	<% end %>
+</div>
+
+<div class="accordion-group my-3" role="tablist" id="accordion-01">
+	<%unless  @result.notes['scopecontent'].blank?%>
+		<% x = render partial: 'shared/multi_notes', locals: {:types => %w(scopecontent),:notitle=> true} %>
+		<%= render partial: 'shared/accordion_panel', locals: {:p_title => 'Scope and Content Note',
+		:p_id => 'scope_content', :p_body => x } %>
+	<%end %>
+
+	<%unless @result.notes['bioghist'].blank?%>
+		<% x = render partial: 'shared/multi_notes', locals: {:types => %w(bioghist),:notitle=> true} %>
+		<%= render partial: 'shared/accordion_panel', locals: {:p_title => 'Biographical/Historical Information',
+																							 :p_id => 'bioghist', :p_body => x } %>
+	<%end %>
+
+	<%unless @result.notes['arrangement'].blank?%>
+		<% x = render partial: 'shared/multi_notes', locals: {:types => %w(arrangement),:notitle=> true} %>
+		<%= render partial: 'shared/accordion_panel', locals: {:p_title => 'Arrangement',
+																							 :p_id => 'arrangement', :p_body => x } %>
+	<%end %>
+
+	<% if @result.kind_of?(Accession) && !@result.deaccessions.blank? %>
+		<% x = render partial: 'shared/present_list', locals: {:list =>  @result.deaccessions.collect{|d| d.fetch('description')}, :list_clss => 'deaccessions'} %>
+		<%= render partial: 'shared/accordion_panel', locals: {:p_title => t('deaccessions'), :p_id => 'deaccessions_list', :p_body => x} %>
+	<% end %>
+
+	<% unless @result.subjects.blank? %>
+		<% x= render partial: 'resources/subject_list', locals: {:list => @result.subjects, :list_clss => 'subjects_list'} %>
+		<%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('subject._plural'),
+																							 :p_id => 'subj_list', :p_body => x} %>
+	<% end %>
+
+	<% unless @result.linked_digital_objects.blank? %>
+		<% x = render partial: 'resources/linked_digital_objects', locals: {:digital_objects => @result.linked_digital_objects} %>
+		<%= render partial: 'shared/accordion_panel', locals: {:p_title => t('linked_digital_objects'), :p_id => 'linked_digital_objects_list', :p_body => x} %>
+	<% end %>
+
+	<% unless @result.container_titles_and_uris.blank? %>
+		<% x = render partial: 'shared/present_list', locals: {:list =>  @result.container_titles_and_uris, :list_clss => 'top_containers'} %>
+		<%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('containers'), :p_id => 'cont_list',
+		:p_body => x} %>
+	<% end %>
+
+	<% if @result.kind_of?(DigitalObject) && !@result.linked_instances.blank? %>
+		<% x = render partial: 'digital_objects/linked_instances', locals: {:instances => @result.linked_instances} %>
+		<%= render partial: 'shared/accordion_panel', locals: {:p_title => t('linked_instances'), :p_id => 'linked_instances_list', :p_body => x} %>
+	<% end %>
+
+	<% unless @result.external_documents.blank? %>
+		<% x = render partial: 'shared/present_list_external_docs', locals: {:list =>  @result.external_documents, :list_clss => 'external_docs'} %>
+		<%= render partial: 'shared/accordion_panel', locals: {:p_title => t('external_docs'), :p_id => 'ext_doc_list', :p_body => x} %>
+	<% end %>
+
+	<% if @result.kind_of?(Resource) && !@result.related_accessions.blank? %>
+		<% x = render partial: 'resources/related_accessions', locals: {:accessions => @result.related_accessions} %>
+		<%= render partial: 'shared/accordion_panel', locals: {:p_title => t('related_accessions'), :p_id => 'related_accessions_list', :p_body => x} %>
+	<% end %>
+
+	<% if @result.kind_of?(Accession) && !@result.related_resources.blank? %>
+		<% x = render partial: 'accessions/related_resources', locals: {:resources => @result.related_resources} %>
+		<%= render partial: 'shared/accordion_panel', locals: {:p_title => t('related_resources'), :p_id => 'related_resources_list', :p_body => x} %>
+	<% end %>
+</div>
+
+<% ASUtils.find_local_directories('public/views/_lower_record_innards.html.erb').each do |template| %>
+	<%= render :file => template if File.exists?(template) %>
+<% end %>

--- a/public/views/resources/_related_accessions.html.erb
+++ b/public/views/resources/_related_accessions.html.erb
@@ -1,0 +1,22 @@
+<h3><%= t('resource._public.related_accessions.accessions') %></h3>
+<ul>
+  <% accessions.each do |accession| %>
+    <li>
+      <% if accession.acquisition_type %>
+        <strong><%= accession.acquisition_type %></strong>:
+      <% end %>
+      <%= link_to accession.display_string, app_prefix(accession.uri) %>
+
+      <% unless accession.deaccessions.empty? %>
+        <div>
+          <h3><%= t('resource._public.related_accessions.deaccessions') %></h3>
+          <ul>
+            <% accession.deaccessions.each do |deaccession| %>
+              <li><%= deaccession['description'] %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/public/views/resources/_resource_alltabs.erb
+++ b/public/views/resources/_resource_alltabs.erb
@@ -1,0 +1,10 @@
+<div class="col-lg mr-3">
+  <ul class="nav nav-tabs pt-2">
+    <%= render partial: 'resources/resource_tab', locals: {:action => :show, :text => t('actions.collection_overview'),
+                                                           :enabled => true, :hidden => false } %>
+    <%= render partial: 'resources/resource_tab', locals: {:action => :infinite, :text => t('actions.hierarch'),
+                                                           :enabled => @has_children, :hidden => false } %>
+    <%= render partial: 'resources/resource_tab', locals: {:action => :inventory, :text => t('actions.numeric'),
+                                                           :enabled => @has_containers, :hidden => AppConfig[:pui_hide][:container_inventory] } %>
+  </ul>
+</div>

--- a/public/views/resources/_resource_tab.erb
+++ b/public/views/resources/_resource_tab.erb
@@ -1,0 +1,22 @@
+<% active = (action.to_s == controller.action_name) %>
+<% unless hidden && !active %>
+  <li class="nav-item"<% unless enabled %>style ="cursor:no-drop" class="disabled"<% end %>>
+  	<% case action
+  		 when :show
+         url = app_prefix("/repositories/#{params[:rid]}/resources/#{params[:id]}")
+  		 when :infinite
+         url = app_prefix("/repositories/#{params[:rid]}/resources/#{params[:id]}/collection_organization")
+  		 when :inventory
+         url = app_prefix("/repositories/#{params[:rid]}/resources/#{params[:id]}/inventory")
+  		 end
+  	%>
+
+    <%=
+      link_to_unless active || !enabled, text, url,:class => "nav-link"  do
+        link_to_if active, text, '#',:class => "nav-link active" do
+          link_to text, "#",:class => "nav-link disabled"
+        end
+      end
+    %>
+  </li>
+<% end %>

--- a/public/views/resources/_resources_subjects.html.erb
+++ b/public/views/resources/_resources_subjects.html.erb
@@ -1,0 +1,10 @@
+<div class="recordrow" style="clear: both" data-uri=<%=uri %>>
+  <div class="card m-2">
+    <button class="btn btn-md btn-light text-primary">
+      <a href=<%=uri %>>
+        <%=title %>
+      </a>
+    </button>
+  </div>
+
+</div>

--- a/public/views/resources/_result.html.erb
+++ b/public/views/resources/_result.html.erb
@@ -1,0 +1,12 @@
+ <%# any result that is going to be presented in a list %>
+ <%# Pry::ColorPrinter.pp(result['json'])%>
+
+<% if !props.fetch(:full,false) %>
+ <div class="card text-center pt-1 pb-1 border" style="clear:both" data-uri="<%= result.uri %>">
+<% end %>
+
+<%= render partial: 'resources/inventory_idbadge', locals: {:result => result, :props => props } %>
+
+<% if !props.fetch(:full,false) %>
+   </div>
+<% end %>

--- a/public/views/resources/_subject_list.html.erb
+++ b/public/views/resources/_subject_list.html.erb
@@ -1,0 +1,95 @@
+<%subjects_list = Hash.new{|h,k| h[k]=Array.new(Array.new)}%>
+<% list.each do |item| %>
+  <!--      Handling subjects-->
+  <%if !item['terms'].nil? %>
+    <%item['terms'].take(1).each do |t_type|%>
+      <%subjects_list[t_type['term_type']] << [t_type['term'],item['uri']]%>
+    <% end %>
+<!--        Handling Names listed as subjects(Agent links)-->
+  <% else %>
+    <%subjects_list['names'] << [item['title'],item['uri']]  %>
+  <%end %>
+<% end %>
+
+<div class="row">
+  <div class="col-sm border-right" >
+    <h6 class="text-center">
+      Topics
+    </h6>
+    <% subjects_list.each do |subject_type, subjects_info| %>
+      <% if subject_type == 'topical' %>
+        <ul class="sidebar ml-0">
+        <% subjects_info.each do |subject_info| %>
+          <li><a href=<%=subject_info[1] %>>
+            <%=subject_info[0] %>
+          </a></li>
+        <% end %>
+        </ul>
+      <% end %>
+    <% end %>
+  </div>
+  <div class="col-sm border-right">
+    <h6 class="text-center">
+      Material Types
+    </h6>
+    <%subjects_list.each do |subject_type, subjects_info| %>
+      <% if subject_type == 'genre_form' %>
+        <ul class="sidebar ml-0">
+        <% subjects_info.each do |subject_info| %>
+         <li> <a href=<%=subject_info[1] %>>
+            <%=subject_info[0] %>
+         </a></li>
+        <% end %>
+        </ul>
+      <% end %>
+    <% end %>
+  </div>
+  <div class="col-sm border-right">
+    <h6 class="text-center">
+      Places
+    </h6>
+    <% subjects_list.each do |subject_type, subjects_info| %>
+      <% if subject_type == 'geographic' %>
+        <ul class="sidebar ml-0">
+        <% subjects_info.each do |subject_info| %>
+         <li> <a href=<%=subject_info[1] %>>
+            <%=subject_info[0] %>
+         </a></li>
+        <% end %>
+        </ul>
+      <% end %>
+    <% end %>
+  </div>
+  <div class="col-sm border-right">
+    <h6 class="text-center ">
+      Occupations
+    </h6>
+    <% subjects_list.each do |subject_type, subjects_info| %>
+      <% if subject_type == 'occupation' %>
+        <ul class="sidebar ml-0">
+        <% subjects_info.each do |subject_info| %>
+          <li><a href=<%=subject_info[1] %>>
+            <%=subject_info[0] %>
+          </a></li>
+        <% end %>
+        </ul>
+      <% end %>
+    <% end %>
+  </div>
+  <div class="col-sm">
+    <h6 class="text-center">
+      Names
+    </h6>
+    <% subjects_list.each do |subject_type, subjects_info| %>
+      <% if subject_type == 'names' %>
+        <ul class="sidebar ml-0">
+        <% subjects_info.each do |subject_info| %>
+          <li><a href=<%=subject_info[1] %>>
+            <%=subject_info[0] %>
+          </a></li>
+        <% end %>
+        </ul>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/public/views/resources/index.html.erb
+++ b/public/views/resources/index.html.erb
@@ -1,0 +1,10 @@
+<div class="row">
+<h2><%= (@repo_name != '' ? "#{@repo_name}: " : '') %><%= @results['total_hits'] %> <%= (@results['total_hits'] == 1 ? t('resource._singular'): t('resource._plural')) %></h2>
+<div class="col-sm-9">
+<%= render partial: 'shared/pagination', locals: {:pager => @pager} %>
+    <% @results['results'].each do |result| %>
+    <%= render partial: 'shared/result', locals: {:result => result, :props => {:full => false, :no_repo => !@repo_name.blank?}} %>
+    <% end %>
+<%= render partial: 'shared/pagination', locals: {:pager => @pager} %>
+</div>
+</div> 

--- a/public/views/resources/infinite.html.erb
+++ b/public/views/resources/infinite.html.erb
@@ -1,0 +1,89 @@
+<a name="main" title="<%= t('internal_links.main') %>"></a>
+<main id="skip-header-target" role="main">
+  <section class="py-3">
+
+    <div class="container description">
+
+      <div class="information col-sm-7">
+      <%= render partial: 'resources/idbadge', locals: {:result => @result, :props => { :full => true} } %>
+      </div>
+      <hr/>
+
+      <%= render partial: 'resources/resource_alltabs' %>
+
+      <%= javascript_include_tag 'treesync' %>
+      <%= javascript_include_tag 'infinite_scroll' %>
+      <%= javascript_include_tag "#{@base_url}/assets/javascripts/largetree" %>
+      <%= javascript_include_tag "#{@base_url}/assets/javascripts/tree_renderer" %>
+
+      <div class="row" id="tabs">
+        <div class="infinite-record-wrapper container-fluid col-8 pl-3">
+          <div class="infinite-record-container" >
+            <div class="root">
+              <h3 class="pt-2">Collection Organization</h3>
+              <% waypoint_size = 20 %>
+              <% @ordered_records.each_slice(waypoint_size).each_with_index do |refs, i| %>
+                <div class="waypoint" data-waypoint-number="<%= i %>" data-waypoint-size=<%= waypoint_size %> data-uris="<%= refs.map {|r| r['ref']}.join(';') %>"></div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+        <div id="sidebar" class="sidebar sidebar-container col-4 ">
+          <% if AppConfig[:pui_search_collection_from_collection_organization] %>
+            <%= render partial: 'shared/search_collection_form', :locals => {:resource_uri => @result['uri'], :action_text => t('actions.search_in', :type => t('resource._singular'))} %>
+          <% end %>
+          <div class="bg-light mt-2 p-2 align-content-center">
+            <h3 class="h5 text-center">Collection Organization</h3>
+          </div>
+          <div class="border">
+            <div class="infinite-tree-view largetree-container pb-2 pl-2" id='tree-container'></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+
+<script>
+ var syncer = new TreeSync('<%= params[:rid]%>');
+ window.syncer = syncer;
+
+ var scroll = new InfiniteScroll('<%= url_for(:action => :show) %>/infinite',
+                                 $('.infinite-record-wrapper'),
+                                 <%= @ordered_records.length %>,
+                                 function() {
+                                     syncer.infiniteScrollIsReady(scroll);
+                                 });
+
+ /* NOTE: This just here for debugging... */
+ window.scroller = scroll;
+ var tree = new LargeTree(new TreeDataSource('<%= url_for(:action => :show) %>/tree'),
+     $('.infinite-tree-view'),
+     '<%= @root_uri %>',
+     true,
+     new SimpleRenderer(),
+     function() {
+         syncer.treeIsReady(tree);
+     },
+     function(current_node, tree) {
+         tree.expandNode(current_node);
+     });
+
+ window.tree = tree;
+</script>
+
+<script>
+  // handle clicks on tree items
+  $('.infinite-record-wrapper').on('click', '.infinite-record-record a.record-title', function(event) {
+      // update the hash so browser-back returns user to the record they clicked
+      var $record = $(this).closest('.infinite-record-record');
+      var uri = $record.data('uri');
+      var tree_id = TreeIds.uri_to_tree_id(uri);
+      location.hash = uri;
+
+      return true;
+  });
+</script>
+
+<%= render partial: 'shared/modal_actions' %>

--- a/public/views/resources/inventory.html.erb
+++ b/public/views/resources/inventory.html.erb
@@ -1,0 +1,34 @@
+<main id="skip-header-target" role="main">
+  <section class="py-3">
+    <div class="container description">
+
+      <%= render partial: 'resources/idbadge', locals: {:result => @result, :props => { :full => true} } %>
+      <hr/>
+
+      <%= render partial: 'resources/resource_alltabs' %>
+      <%@results.records.sort_by!{|record| [record.display_string]}%>
+      <div class="row matrix-gutter">
+        <div class="col-sm-8">
+          <div class ="tab-content clearfix pt-2">
+            <div class="card-columns">
+              <% unless @results.blank? || @results['total_hits'] == 0 %>
+                <% @results.records.each do |result| %>
+                  <%= render partial: 'resources/result', locals: {:result => result, :props => {:full => false}} %>
+                <% end %>
+                  <%= render partial: 'shared/pagination', locals: {:pager  => @pager}  %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+        <div id="sidebar" class="col-sm-4 sidebar sidebar-container">
+          <% unless @results.blank? || @results['total_hits'] == 0 %>
+            <%= render partial: 'shared/children_tree', :locals => {:heading_text => t('cont_arr'), :root_node_uri => @result.uri, :current_node_uri => @result.uri} %>
+          <% end %>
+        </div>
+      </div>
+
+      <%= render partial: 'shared/modal_actions' %>
+    </div>
+  </section>
+</main>

--- a/public/views/resources/show.html.erb
+++ b/public/views/resources/show.html.erb
@@ -1,0 +1,23 @@
+ <main id="skip-header-target" role="main">
+    <section class="py-3">
+      <div class="container description">
+        <%= render partial: 'resources/idbadge', locals: {:result => @result, :props => { :full => true} } %>
+        <hr/>
+        <%= render partial: 'resources/resource_alltabs' %>
+
+        <div class="row" id="notes_row">
+          <div class="col-8">
+            <%= render partial: 'shared/digital', locals: {:dig_objs => @dig} %>
+            <%= render partial: 'resources/record_innards' %>
+          </div>
+          <div id="sidebar" class="col-4" <% unless @has_children %>style="display: none"<% end %>>
+            <% if defined?(@filters) && defined?(@search) %>
+            <%= render partial: 'shared/facets' %>
+           <% end %>
+           <%= render partial: 'shared/children_tree', :locals => {:heading_text => t('cont_arr'), :root_node_uri => @result.uri, :current_node_uri => @result.uri} %>
+          </div>
+        </div>
+        <%= render partial: 'shared/modal_actions' %>
+      </div>
+    </section>
+  </main>

--- a/public/views/shared/_accordion_panel.html.erb
+++ b/public/views/shared/_accordion_panel.html.erb
@@ -1,0 +1,14 @@
+<div class="card">
+  <a class="card-header h4 collapse collapsed" id="<%= p_id %>" data-toggle="collapse" href="#panel-<%= p_id %>"   role="tab" aria-expanded="false" aria-controls="panel-<%=p_id %>">
+    <span class="title" role="heading" aria-level="3">
+      <%= p_title %>
+    </span>
+  </a>
+
+  <div class="collapse" id="panel-<%= p_id %>" role="tabpanel" aria-labelledby="<%= p_id %>" data-parent="#accordion-01">
+    <div class="card-body bg-white">
+      <%= p_body %>
+    </div>
+  </div>
+
+</div>

--- a/public/views/shared/_children_tree.html.erb
+++ b/public/views/shared/_children_tree.html.erb
@@ -1,0 +1,30 @@
+<%= javascript_include_tag "#{@base_url}/assets/javascripts/largetree" %>
+<%= javascript_include_tag "#{@base_url}/assets/javascripts/tree_renderer" %>
+<div class="bg-light mt-2 p-2 align-content-center">
+  <h3 class="h5 text-center"><%= heading_text %></h3>
+</div>
+  <div class="border pl-2 pb-2">
+<div class="infinite-tree-view largetree-container" id='tree-container'></div>
+  </div>
+</div>
+<script>
+
+    var root_uri = '<%= app_prefix(root_node_uri) %>';
+    var should_link_to_record = true;
+
+    var tree = new LargeTree(new TreeDataSource(root_uri + '/tree'),
+        $('#tree-container'),
+        root_uri,
+        true,
+        new SimpleRenderer(should_link_to_record),
+        function() {
+            var tree_id = TreeIds.uri_to_tree_id('<%= current_node_uri %>');
+            tree.setCurrentNode(tree_id, function() {
+                // scroll to selected node
+                tree.elt.scrollTo('#'+tree_id, 0, {offset: -50});
+            });
+        },
+        function(current_node, tree) {
+          tree.expandNode(current_node);
+        });
+</script>

--- a/public/views/shared/_dates.html.erb
+++ b/public/views/shared/_dates.html.erb
@@ -1,4 +1,4 @@
-<% if dates.length == 1 %> class="dates-is-single-date"<% end %>
+<p<% if dates.length == 1 %> class="dates-is-single-date"<% end %>>
 <% dates.each_with_index do |date, ndx| %>
   <% if ndx == dates.size - 1 %>
     <span class=dates><%= inheritance(date['_inherited']).html_safe %><%= date['final_expression'] %></span>
@@ -6,3 +6,4 @@
     <span class=dates><%= inheritance(date['_inherited']).html_safe %><%= date['final_expression'] %>,</span>
   <% end %>
 <% end %>
+</p>

--- a/public/views/shared/_multi_notes.html.erb
+++ b/public/views/shared/_multi_notes.html.erb
@@ -1,0 +1,10 @@
+<% types.each do |type|
+	(@result.notes[type] || []).each do |note_struct|
+	   if !note_struct['note_text'].blank? %>
+	    <div class="note">
+	      <%= render  partial: 'shared/single_note',
+	          locals: {:type => type, :note_struct => note_struct,:notitle =>(defined?(notitle))? notitle : false}  %>
+	    </div>
+	   <% end %>
+	<% end %>
+<% end %>

--- a/public/views/shared/_single_note.html.erb
+++ b/public/views/shared/_single_note.html.erb
@@ -1,0 +1,33 @@
+<%  if !note_struct['note_text'].blank? %>
+    <div class="<%= type %> single_note" >
+     <% unless defined?(notitle) &&  notitle %>
+      <%=((defined?(title_desc))? "<h"+title_desc+">": '<h3>').html_safe %> <%= note_struct['label'] %> <%=((defined? (title_desc))? "</h"+title_desc+">" : '</h3>').html_safe%>
+     <% end %>
+     <% if note_struct.has_key?('subnotes') %>
+       <% note_struct['subnotes'].each do |subnote| %>
+         <div class="subnote <%= 'well' if subnote['jsonmodel_type'] == 'note_citation' %>">
+           <% if subnote['jsonmodel_type'] == 'note_citation' %>
+             <h4><%= t('actions.cite') %></h4>
+           <% elsif subnote['_title'] %>
+             <h4><%= subnote['_title'] %></h4>
+           <% elsif subnote['_inline_label'] %>
+             <span class='inline-label'><%= subnote['_inline_label'] %></span>
+           <% end %>
+           <span class="note-content">
+             <% unless note_struct['is_inherited'].blank? %>
+               <%= inheritance(note_struct['is_inherited']).html_safe %>
+             <% end %>
+             <%= subnote['_text'].html_safe %>
+           </span>
+         </div>
+       <% end %>
+     <% else %>
+       <div class="note-content">
+         <% unless note_struct['is_inherited'].blank? %>
+           <%= inheritance(note_struct['is_inherited']).html_safe %>
+         <% end %>
+         <%= note_struct['note_text'].html_safe %>
+       </div>
+     <% end %>
+     </div>
+<% end %>


### PR DESCRIPTION
-Updated design according to nyc-core-framework
- Removed infinite scroll from 'Collection Organization' tab
-Listed subjects in 'Collection Overview' tab according to sub-category in columnar format
-Redesigned sidebar
-Removed duplicated data on 'Collection overview' tab
-Removed 'Expand All; from 'Collection overview' tab and made each section individually collapsible
-Removed 'Additional Description' and created separate sections for each information
