### PR TITLE
AB#552 - Redesigned View Single Subject Page

### DIFF
--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -31,3 +31,5 @@ en:
   navbar:
     search_placeholder: Search by keyword
     advanced_search_placeholder: Search
+
+  related_to: "Related to %{count} %{type}"

--- a/public/views/shared/_global_search.html.erb
+++ b/public/views/shared/_global_search.html.erb
@@ -2,15 +2,14 @@
   <a name="search" id="search"></a>
   <% @search = Search.new unless defined?(@search) %>
   <%= form_tag(app_prefix("#{search_url}"), method: 'get', :id => 'global_search', class: 'narrow py-2', aria: {label: 'Search'}) do %> <!-- form tag begin -->
-    <% (0...[1, @search.q.length].max).each do |i| %> <!-- Query loop begin -->
-      <div class="input-group" id="global_search_row_<%= i %>">
+      <div class="input-group" id="global_search_row">
         <div class="col-sm-1 bool form-group form-inline hidden">
-          <%= label_tag("op#{i}", t('advanced_search.operator_label'), :class => 'sr-only') %>
-          <%= select_tag('op[]', options_for_select(Search.get_boolean_opts, @search[:op][i]), disabled: (i == 0), :id => "global_search_op#{i}", :class => 'form-control' + (i == 0 ? ' hidden' : '')) %>
-          <%= hidden_field_tag('op[]', '', :id => 'global_search_op_') if i == 0 %>
+          <%= label_tag("op", t('advanced_search.operator_label'), :class => 'sr-only') %>
+          <%= select_tag('op[]', options_for_select(Search.get_boolean_opts, @search[:op][0]), disabled: true, :id => "global_search_op", :class => 'form-control hidden') %>
+          <%= hidden_field_tag('op[]', '', :id => 'global_search_op') %>
         </div>
         <%= label_tag(:"global-search-bar", t('navbar.search_placeholder'), :class => 'sr-only repeats') %>
-        <%= text_field_tag('q[]', @search[:q][i], :placeholder => t('navbar.search_placeholder'), :value => '', :id => 'global-search-bar',
+        <%= text_field_tag('q[]', @search[:q][0], :placeholder => t('navbar.search_placeholder'), :value => '', :id => 'global-search-bar',
                            :class => 'form-control form-control-lg') %>
         <div class="input-group-btn">
           <%= button_tag(type: 'submit', class: "btn btn-primary btn-lg", id: 'submit_global_search', name: 'commit', value: 'Search', title: 'Search', data: {disable_with: '<span class="fas fa-arrow-right" role="img"></span>'}) do %>
@@ -20,6 +19,5 @@
           <span><small><a href="<%=  app_prefix('/search?reset=true') %>" title="<%= I18n.t('search_tab', :target => t('archive._plural'))%>" class="advanced-search-link">advanced search</a></small></span>
         </div>
       </div>
-    <% end %> <!-- Query loop end -->
   <% end %> <!-- Form tag end -->
 </div>

--- a/public/views/subjects/_idbadge.html.erb
+++ b/public/views/subjects/_idbadge.html.erb
@@ -55,7 +55,7 @@
   <% comp_id = display_component_id(result, props.fetch(:infinite_item, false)) %>
   <% unless comp_id.blank? %>
     <div class="identifier">
-      <small><%=t('resource._singular') %> <%= comp_id %></small>
+      <small><strong><%=t('resource._singular') %> <%= comp_id %></strong></small>
     </div>
   <% end %>
 </div>

--- a/public/views/subjects/_idbadge.html.erb
+++ b/public/views/subjects/_idbadge.html.erb
@@ -1,0 +1,61 @@
+<%
+  if result.level
+    if result.primary_type =~ /digital_object/
+      level = I18n.t("enumerations.digital_object_level.#{result.level}", :default => result.level)
+      badge_label = I18n.t("digital_object._public.badge_label", :level => level)
+    else
+      level = result.level == 'otherlevel' ? result.other_level : result.level
+      badge_label = I18n.t("enumerations.archival_record_level.#{level}", :default => level)
+    end
+  else
+    badge_label = t("#{result.primary_type}._singular")
+  end
+%>
+
+
+<%# build URL with slugs depending on the primary type %>
+<% case result.primary_type %>
+<% when "resource" %>
+  <% url = resource_base_url(result) %>
+<% when "archival_object" %>
+  <% url = archival_object_base_url(result) %>
+<% when "digital_object" %>
+  <% url = digital_object_base_url(result) %>
+<% when "accession" %>
+  <% url = accession_base_url(result) %>
+<% when "subject" %>
+  <% url = subject_base_url(result) %>
+<% when "classification" %>
+  <% url = classification_base_url(result) %>
+<% when "agent_person" %>
+  <% url = agent_base_url(result) %>
+<% when "agent_family" %>
+  <% url = agent_base_url(result) %>
+<% when "agent_corporate_entity" %>
+  <% url = agent_base_url(result) %>
+<% when "agent_software" %>
+  <% url = agent_base_url(result) %>
+<% else %>
+  <% url = result.uri %>
+<% end %>
+
+<%= (props.fetch(:full,false)? '<h1>' : '<h3>').html_safe %>
+<% if !props.fetch(:full,false) %>
+  <a class="record-title" href="<%= app_prefix(url) %>">
+    <%== props.fetch(:infinite_item, false) ? result.parse_full_title(true) : result.display_string %>
+  </a>
+<% else %>
+  <%== result.display_string %>
+<% end %>
+<%= (props.fetch(:full,false)? '</h1>' : '</h3>').html_safe %>
+
+
+<div class="badge-and-identifier">
+
+  <% comp_id = display_component_id(result, props.fetch(:infinite_item, false)) %>
+  <% unless comp_id.blank? %>
+    <div class="identifier">
+      <small><%=t('resource._singular') %> <%= comp_id %></small>
+    </div>
+  <% end %>
+</div>

--- a/public/views/subjects/_only_facets.html.erb
+++ b/public/views/subjects/_only_facets.html.erb
@@ -1,0 +1,49 @@
+<% unless @facets.blank? %>
+  <dl id="facets">
+
+    <%
+      preferred_facet_order = %w(repository primary_type agents subjects langcode)
+      ordered_facet_types = @facets.keys.sort{|a,b|
+        if preferred_facet_order.include?(a) && preferred_facet_order.include?(b)
+          preferred_facet_order.index(a) <=> preferred_facet_order.index(b)
+        elsif preferred_facet_order.include?(a)
+          -1
+        elsif preferred_facet_order.include?(b)
+          1
+        else
+          0
+        end
+      }
+    %>
+
+    <% ordered_facet_types.each do |type| %>
+      <% h = @facets.fetch(type, false) %>
+      <% next unless h %>
+      <dt><%= t("search_results.filter.#{type}") %></dt>
+      <ul>
+        <% facet_count = 0 %>
+        <% h.each do |v, ct| %>
+          <% if facet_count == 5 %>
+            <div class="more-facets">
+              <button class="more btn btn-outline-dark btn-sm mt-2"> more &nbsp;<span class="fa fa-sm fa-plus"></span></button>
+              <div class="below-the-fold">
+          <% end %>
+          <% facet_count += 1 %>
+          <li class="small">
+            <a href="<%= app_prefix("#{@page_search}&filter_fields[]=#{type}&filter_values[]=#{CGI.escape(v)}") %>"
+               rel="nofollow"
+               title="<%= t('search_results.filter_by')%> '<%= get_pretty_facet_value(type,v) %>'">
+              <%= get_pretty_facet_value(type,v) %>
+            </a>
+            <span class="recordnumber"><b>(<%= ct %>)</b></span>
+          </li>
+        <% end %>
+        <% if facet_count > 5 %>
+          <button class="less btn btn-outline-dark btn-sm mt-2"> less &nbsp;<span class="fa fa-sm fa-minus"></span></button>
+          </div>
+          </div>
+        <% end %>
+      </ul>
+    <% end %>
+  </dl>
+<% end %>

--- a/public/views/subjects/_result.html.erb
+++ b/public/views/subjects/_result.html.erb
@@ -19,7 +19,7 @@
        note_struct = result.note('scopecontent')
      end
      if !note_struct['note_text'].blank? %>
-    <div class="abstract single_note"><span class='inline-label'><%= note_struct['label'] %></span>
+    <div class="abstract single_note"><strong><span class='inline-label'><%= note_struct['label'] %></span>:</strong>
       <% unless note_struct['is_inherited'].blank? %>
         <%= inheritance(note_struct['is_inherited']).html_safe %>
       <% end %>

--- a/public/views/subjects/_result.html.erb
+++ b/public/views/subjects/_result.html.erb
@@ -1,0 +1,113 @@
+<%# any result that is going to be presented in a list %>
+<%# Pry::ColorPrinter.pp(result['json'])%>
+<% if !props.fetch(:full, false) %>
+  <tr data-uri="<%= result.uri %>">
+<% end %>
+
+<td class="p-2">
+  <%= render partial: 'subjects/idbadge', locals: {:result => result, :props => props} %>
+  <br>
+
+  <% if !result['parent_institution_name'].blank? %>
+    <div><strong><%= t('parent_inst') %>:</strong>
+      <%= result['parent_institution_name'] %>
+    </div>
+  <% end %>
+
+  <% note_struct = result.note('abstract')
+     if note_struct.blank?
+       note_struct = result.note('scopecontent')
+     end
+     if !note_struct['note_text'].blank? %>
+    <div class="abstract single_note"><span class='inline-label'><%= note_struct['label'] %></span>
+      <% unless note_struct['is_inherited'].blank? %>
+        <%= inheritance(note_struct['is_inherited']).html_safe %>
+      <% end %>
+      <% if note_struct['note_text'].length > AppConfig[:abstract_note_length] %>
+        <% truncated_note = note_struct['note_text'][0..AppConfig[:abstract_note_length] - 1] %>
+        <% end_index = truncated_note.rindex(' ') || AppConfig[:abstract_note_length] - 1 %>
+        <%= (strip_tags(truncated_note[0..end_index - 1]) + '...').html_safe %>
+      <% else %>
+        <%= note_struct['note_text'].html_safe %>
+      <% end %>
+    </div>
+  <% end %>
+  <% unless props.fetch(:no_repo, false) %>
+    <% r_uri = nil
+       r_name = nil
+       if result['json']['repository'] && result['json']['repository']['_resolved'] && (!result['json']['repository']['ref'].blank? || !result['json']['repository']['_resolved']['name'].blank?)
+         r_uri = result['json']['repository']['ref'] || ''
+         r_name = result['json']['repository']['_resolved']['name'] || ''
+       elsif result['_resolved_repository'] && result['_resolved_repository']['json']
+         r_uri = result['_resolved_repository']['json']['uri'] || ''
+         r_name = result['_resolved_repository']['json']['name'] || ''
+       end
+    %>
+  <% end %>
+
+  <br>
+
+  <% if result['json'].has_key?('dates') || result['json'].has_key?('dates_of_existence') %>
+    <div class="dates">
+
+      <% dates = (result['json']['dates'] || result['json']['dates_of_existence']
+      ).collect { |date| parse_date(date) }.reject { |label, expression| expression.blank? } %>
+      <% unless dates.empty? %>
+        <strong><%= t('dates') %>: </strong>
+      <% end %>
+      <%= dates.collect { |label, expression| label.blank? ? expression : "#{label}#{expression}" }.join('; ') %>
+    </div>
+  <% end %>
+
+  <br>
+
+  <% if result.resolved_repository %>
+    <div class="result_context">
+      <strong><%= t('context') %>: </strong>
+      <span class="repo_name">
+          <%= link_to result.resolved_repository.fetch('name'),
+                      app_prefix(repository_base_url(
+                                     "uri" => result.resolved_repository.fetch('uri'),
+                                     "slug" => result.resolved_repository.fetch('slug') { |s| nil })) %>
+        </span>
+
+      <% if result.respond_to?(:ancestors) && result.ancestors %>
+        <% result.ancestors.each do |ancestor| %>
+          <%= t('context_delimiter') %>
+          <span class="ancestor">
+            <% identifier = ancestor.has_key?('id_0') ? (0..3).collect { |i| ancestor["id_#{i}"] }.compact.join('-') : nil %>
+            <% title = process_mixed_content(ancestor.fetch('title', "[#{ ancestor.fetch('level', 'untitled')}]")).html_safe %>
+            <%= link_to (identifier.blank? ? title : "#{identifier}, #{title}"), app_prefix(ancestor.fetch('uri')) %>
+            </span>
+        <% end %>
+      <% else %>
+        <% unless props.fetch(:no_res, false) || result.resolved_resource.blank? %>
+          <%= t('context_delimiter') %>
+          <span class="resource_name">
+              <%= link_to process_mixed_content(result.resolved_resource.fetch('title')).html_safe, app_prefix(result.resolved_resource.fetch('uri')) %>
+            </span>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+
+
+  <% if !props.fetch(:full, false) && result['primary_type'] == 'repository' %>
+    <div><strong><%= t('number_of', {:type => t('resource._plural')}) %></strong> <%= @counts[result.uri]['resource'] %>
+    </div>
+  <% end %>
+
+  <% if result.primary_type == 'classification' && result.classification_terms? %>
+    <div class="classification-subgroups">
+      <button class="btn btn-default btn-sm subgroup-toggle" aria-pressed="false">
+        <i aria-hidden="true" class="fa fa-plus"></i>
+        <%= t('classification._public.actions.show_subgroups') %>
+      </button>
+      <div class="classification-subgroups-tree largetree-container" style="display: none;"></div>
+    </div>
+  <% end %>
+</td>
+
+<% if !props.fetch(:full, false) %>
+  </tr>
+<% end %>

--- a/public/views/subjects/_result.html.erb
+++ b/public/views/subjects/_result.html.erb
@@ -6,7 +6,6 @@
 
 <td class="p-2">
   <%= render partial: 'subjects/idbadge', locals: {:result => result, :props => props} %>
-  <br>
 
   <% if !result['parent_institution_name'].blank? %>
     <div><strong><%= t('parent_inst') %>:</strong>
@@ -19,7 +18,7 @@
        note_struct = result.note('scopecontent')
      end
      if !note_struct['note_text'].blank? %>
-    <div class="abstract single_note"><strong><span class='inline-label'><%= note_struct['label'] %></span>:</strong>
+    <div class="abstract single_note pt-1"><strong><span class='inline-label'><%= note_struct['label'] %></span>:</strong>
       <% unless note_struct['is_inherited'].blank? %>
         <%= inheritance(note_struct['is_inherited']).html_safe %>
       <% end %>
@@ -45,10 +44,8 @@
     %>
   <% end %>
 
-  <br>
-
   <% if result['json'].has_key?('dates') || result['json'].has_key?('dates_of_existence') %>
-    <div class="dates">
+    <div class="dates pt-1">
 
       <% dates = (result['json']['dates'] || result['json']['dates_of_existence']
       ).collect { |date| parse_date(date) }.reject { |label, expression| expression.blank? } %>
@@ -58,39 +55,6 @@
       <%= dates.collect { |label, expression| label.blank? ? expression : "#{label}#{expression}" }.join('; ') %>
     </div>
   <% end %>
-
-  <br>
-
-  <% if result.resolved_repository %>
-    <div class="result_context">
-      <strong><%= t('context') %>: </strong>
-      <span class="repo_name">
-          <%= link_to result.resolved_repository.fetch('name'),
-                      app_prefix(repository_base_url(
-                                     "uri" => result.resolved_repository.fetch('uri'),
-                                     "slug" => result.resolved_repository.fetch('slug') { |s| nil })) %>
-        </span>
-
-      <% if result.respond_to?(:ancestors) && result.ancestors %>
-        <% result.ancestors.each do |ancestor| %>
-          <%= t('context_delimiter') %>
-          <span class="ancestor">
-            <% identifier = ancestor.has_key?('id_0') ? (0..3).collect { |i| ancestor["id_#{i}"] }.compact.join('-') : nil %>
-            <% title = process_mixed_content(ancestor.fetch('title', "[#{ ancestor.fetch('level', 'untitled')}]")).html_safe %>
-            <%= link_to (identifier.blank? ? title : "#{identifier}, #{title}"), app_prefix(ancestor.fetch('uri')) %>
-            </span>
-        <% end %>
-      <% else %>
-        <% unless props.fetch(:no_res, false) || result.resolved_resource.blank? %>
-          <%= t('context_delimiter') %>
-          <span class="resource_name">
-              <%= link_to process_mixed_content(result.resolved_resource.fetch('title')).html_safe, app_prefix(result.resolved_resource.fetch('uri')) %>
-            </span>
-        <% end %>
-      <% end %>
-    </div>
-  <% end %>
-
 
   <% if !props.fetch(:full, false) && result['primary_type'] == 'repository' %>
     <div><strong><%= t('number_of', {:type => t('resource._plural')}) %></strong> <%= @counts[result.uri]['resource'] %>

--- a/public/views/subjects/_terms.html.erb
+++ b/public/views/subjects/_terms.html.erb
@@ -1,6 +1,0 @@
-<dl>
-  <% terms.each do |term|  %>
-    <dt><%= t("enumerations.subject_term_type.#{term['term_type']}") %></dt>
-    <dd><%= term['term'] %></dd>
-  <% end %>
-</dl>

--- a/public/views/subjects/_terms.html.erb
+++ b/public/views/subjects/_terms.html.erb
@@ -1,0 +1,6 @@
+<dl>
+  <% terms.each do |term|  %>
+    <dt><%= t("enumerations.subject_term_type.#{term['term_type']}") %></dt>
+    <dd><%= term['term'] %></dd>
+  <% end %>
+</dl>

--- a/public/views/subjects/show.html.erb
+++ b/public/views/subjects/show.html.erb
@@ -1,0 +1,64 @@
+<main id="skip-header-target" role="main">
+  <section class="py-3">
+    <div class="container">
+      <!--      top part-->
+      <div class="row pb-2 justify-content-between">
+        <div class="col"><h2><%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %></h2></div>
+      </div>
+      <div class="row pb-2 justify-content-between hidden">
+        <!--        Page actions probably not needed for subjects-->
+        <div class="col"><%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath } %></div>
+      </div>
+      <div class="row pb-1 justify-content-between">
+        <div class="col"><span class="inline-label clear"><strong><%= t('enumeration_names.subject_source') %></strong>: </span><%= t("enumerations.subject_source.#{@result['json']['source']}" ) %></div>
+      </div>
+
+      <div>
+        <!--        This section is probably not needed for subjects-->
+        <% if !@result.dates.blank? %>
+          <% render partial: 'shared/dates', locals: {:dates => @result.dates} %>
+        <% end %>
+
+        <% if !@result['json']['component_id'].blank? %>
+          <span class='component'><%= t(component._singular) %>: <%= @result['json']['component_id'] %></span>
+        <% end %>
+        <% if !@result['json']['ref_id'].blank? %>
+          <span class='ref_id'>[Ref. ID: <%= @result['json']['ref_id'] %>]</span>
+        <% end %>
+        <% if @result['json']['scope_note'].present? %>
+          <span class="inline-label"><%= t('scope_note') %>
+            :</span> <%= process_mixed_content(@result['json']['scope_note']).html_safe %>
+        <% end %>
+        <%= render partial: 'shared/display_notes' %>
+      </div>
+
+      <!--      table rows-->
+      <div class="row matrix-gutter">
+        <div class="col-lg-8 mr-3">
+          <% unless @results.blank? || @results['total_hits'] == 0 %>
+            <h3><%= t('found', {:count => @results['total_hits'], :type => @results['total_hits'] == 1? t('coll_obj._singular') : t('coll_obj._plural')}) %>:</h3>
+            <hr>
+            <table class="table">
+              <tbody>
+              <% @results.records.each do |result| %>
+                <%= render partial: 'subjects/result', locals: {:result => result, :props => {:full => false}} %>
+              <% end %>
+              </tbody>
+            </table>
+            <%= render partial: 'shared/pagination', locals: {:pager  => @pager}  %>
+          <% end %>
+        </div>
+
+        <!--        side bar-->
+        <div class="col-lg-3 ml-4">
+          <h2 class="h4">Additional filters:</h2>
+          <div class="bg-light p-3">
+            <%= render partial: 'subjects/only_facets' %>
+          </div>
+        </div>
+      </div>
+      <!-- .row -->
+    </div>
+    <!-- .container -->
+  </section>
+</main>

--- a/public/views/subjects/show.html.erb
+++ b/public/views/subjects/show.html.erb
@@ -4,7 +4,7 @@
       <div class="col">
         <!-- Top headings-->
         <div class="row pb-1 justify-content-between">
-          <div class="col pl-6"><h2><%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %></h2></div>
+          <div class="col pl-6"><%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %></div>
         </div>
         <div class="row pb-1 justify-content-between hidden">
           <!-- Page actions probably not needed for subjects-->
@@ -39,7 +39,7 @@
       <div class="row matrix-gutter justify-content-center">
         <div class="col-8">
           <% unless @results.blank? || @results['total_hits'] == 0 %>
-            <h3 class="pl-2"><%= t('found', {:count => @results['total_hits'], :type => @results['total_hits'] == 1? t('coll_obj._singular') : t('coll_obj._plural')}) %>:</h3>
+            <h2 class="pl-2"><%= t('related_to', {:count => @results['total_hits'], :type => @results['total_hits'] == 1? t('coll_obj._singular') : t('coll_obj._plural')}) %>:</h2>
             <hr>
             <table class="table">
               <tbody>
@@ -54,25 +54,13 @@
 
         <!-- Side bar-->
         <div class="col-3">
-          <h3><%= t('more_about') %> '<%= @result.display_string %>'</h3>
-
-          <div class="acc_holder clear">
-            <div class="accordion-group" role="tablist" id="accordion-01">
-              <% if !(terms = ASUtils.wrap(@result['json']['terms'])).empty? %>
-                <% x = render partial: 'subjects/terms', locals: {:terms =>  terms, :list_clss => 'terms'} %>
-                <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('subject_term_type'), :p_id => 'subject_terms', :p_body => x} %>
-              <% end %>
-              <% unless @result.external_documents.blank? %>
-                <% x = render partial: 'shared/present_list_external_docs', locals: {:list =>  @result.external_documents, :list_clss => 'external_docs'} %>
-                <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('external_docs'), :p_id => 'ext_doc_list', :p_body => x} %>
-              <% end %>
-            </div>
-          </div>
-
+          <h3>Subject Term Details</h3>
+          <% if !(terms = ASUtils.wrap(@result['json']['terms'])).empty? %>
+            <%= render partial: 'subjects/terms', locals: {:terms =>  terms, :list_clss => 'terms'} %>
+          <% end %>
           <br>
-
           <div id="subject-facets" <% if @facets.blank? %>class="hidden"<% end %>>
-            <h2 class="h4">Filter by:</h2>
+            <h3>Filter by:</h3>
             <div class="bg-light p-3">
               <%= render partial: 'subjects/only_facets' %>
             </div>

--- a/public/views/subjects/show.html.erb
+++ b/public/views/subjects/show.html.erb
@@ -51,6 +51,23 @@
 
         <!-- Side bar-->
         <div class="col-3">
+          <h3><%= t('more_about') %> '<%= @result.display_string %>'</h3>
+
+          <div class="acc_holder clear" >
+            <div class="accordion-group" role="tablist" id="accordion-01">
+              <% if !(terms = ASUtils.wrap(@result['json']['terms'])).empty? %>
+                <% x = render partial: 'subjects/terms', locals: {:terms =>  terms, :list_clss => 'terms'} %>
+                <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('subject_term_type'), :p_id => 'subject_terms', :p_body => x} %>
+              <% end %>
+              <% unless @result.external_documents.blank? %>
+                <% x = render partial: 'shared/present_list_external_docs', locals: {:list =>  @result.external_documents, :list_clss => 'external_docs'} %>
+                <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('external_docs'), :p_id => 'ext_doc_list', :p_body => x} %>
+              <% end %>
+            </div>
+          </div>
+
+          <br>
+
           <div id="subject-facets" <% if @facets.blank? %>class="hidden"<% end %>>
             <h2 class="h4">Additional filters:</h2>
             <div class="bg-light p-3">

--- a/public/views/subjects/show.html.erb
+++ b/public/views/subjects/show.html.erb
@@ -59,6 +59,13 @@
             <%= render partial: 'subjects/terms', locals: {:terms =>  terms, :list_clss => 'terms'} %>
           <% end %>
           <br>
+          <% unless @result.external_documents.blank? %>
+            <h3>External Documents</h3>
+            <% unless @result.external_documents.blank? %>
+              <%= render partial: 'shared/present_list_external_docs', locals: {:list =>  @result.external_documents, :list_clss => 'external_docs'} %>
+            <% end %>
+          <% end %>
+          <br>
           <div id="subject-facets" <% if @facets.blank? %>class="hidden"<% end %>>
             <h3>Filter by:</h3>
             <div class="bg-light p-3">

--- a/public/views/subjects/show.html.erb
+++ b/public/views/subjects/show.html.erb
@@ -1,20 +1,20 @@
 <main id="skip-header-target" role="main">
-  <section class="py-3">
-    <div class="container">
-      <!--      top part-->
+  <section class="py-3 d-flex justify-content-center">
+    <div class="container-fluid mx-3">
+      <!-- Top headings-->
       <div class="row pb-2 justify-content-between">
-        <div class="col"><h2><%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %></h2></div>
+        <div class="col pl-7"><h2><%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %></h2></div>
       </div>
       <div class="row pb-2 justify-content-between hidden">
-        <!--        Page actions probably not needed for subjects-->
+        <!-- Page actions probably not needed for subjects-->
         <div class="col"><%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath } %></div>
       </div>
       <div class="row pb-1 justify-content-between">
-        <div class="col"><span class="inline-label clear"><strong><%= t('enumeration_names.subject_source') %></strong>: </span><%= t("enumerations.subject_source.#{@result['json']['source']}" ) %></div>
+        <div class="col pl-7"><span class="inline-label clear"><strong><%= t('enumeration_names.subject_source') %></strong>: </span><%= t("enumerations.subject_source.#{@result['json']['source']}" ) %></div>
       </div>
 
+      <!-- This section is probably not needed for subjects -->
       <div>
-        <!--        This section is probably not needed for subjects-->
         <% if !@result.dates.blank? %>
           <% render partial: 'shared/dates', locals: {:dates => @result.dates} %>
         <% end %>
@@ -32,11 +32,11 @@
         <%= render partial: 'shared/display_notes' %>
       </div>
 
-      <!--      table rows-->
-      <div class="row matrix-gutter">
-        <div class="col-lg-8 mr-3">
+      <!-- Table rows -->
+      <div class="row matrix-gutter justify-content-center">
+        <div class="col-8">
           <% unless @results.blank? || @results['total_hits'] == 0 %>
-            <h3><%= t('found', {:count => @results['total_hits'], :type => @results['total_hits'] == 1? t('coll_obj._singular') : t('coll_obj._plural')}) %>:</h3>
+            <h3 class="pl-2"><%= t('found', {:count => @results['total_hits'], :type => @results['total_hits'] == 1? t('coll_obj._singular') : t('coll_obj._plural')}) %>:</h3>
             <hr>
             <table class="table">
               <tbody>
@@ -49,11 +49,13 @@
           <% end %>
         </div>
 
-        <!--        side bar-->
-        <div class="col-lg-3 ml-4">
-          <h2 class="h4">Additional filters:</h2>
-          <div class="bg-light p-3">
-            <%= render partial: 'subjects/only_facets' %>
+        <!-- Side bar-->
+        <div class="col-3">
+          <div id="subject-facets" <% if @facets.blank? %>class="hidden"<% end %>>
+            <h2 class="h4">Additional filters:</h2>
+            <div class="bg-light p-3">
+              <%= render partial: 'subjects/only_facets' %>
+            </div>
           </div>
         </div>
       </div>

--- a/public/views/subjects/show.html.erb
+++ b/public/views/subjects/show.html.erb
@@ -4,14 +4,14 @@
       <div class="col">
         <!-- Top headings-->
         <div class="row pb-1 justify-content-between">
-          <div class="col pl-6"><%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %></div>
+          <div class="col pl-5"><%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %></div>
         </div>
         <div class="row pb-1 justify-content-between hidden">
           <!-- Page actions probably not needed for subjects-->
-          <div class="col"><%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath } %></div>
+          <div class="col pl-5"><%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath } %></div>
         </div>
         <div class="row pb-1 justify-content-between">
-          <div class="col pl-6"><span class="inline-label clear"><strong><%= t('enumeration_names.subject_source') %></strong>: </span><%= t("enumerations.subject_source.#{@result['json']['source']}" ) %></div>
+          <div class="col pl-5"><span class="inline-label clear"><strong><%= t('enumeration_names.subject_source') %></strong>: </span><%= t("enumerations.subject_source.#{@result['json']['source']}" ) %></div>
         </div>
 
         <% if !@result.dates.blank? %>
@@ -26,7 +26,7 @@
         <% end %>
         <% if @result['json']['scope_note'].present? %>
           <div class="row pb-1 justify-content-between">
-            <div class="col pl-6">
+            <div class="col pl-5">
               <span class="inline-label"><strong><%= t('scope_note') %>
                 : </strong></span> <%= process_mixed_content(@result['json']['scope_note']).html_safe %>
             </div>
@@ -39,8 +39,6 @@
       <div class="row matrix-gutter justify-content-center">
         <div class="col-8">
           <% unless @results.blank? || @results['total_hits'] == 0 %>
-            <h2 class="pl-2"><%= t('related_to', {:count => @results['total_hits'], :type => @results['total_hits'] == 1? t('coll_obj._singular') : t('coll_obj._plural')}) %>:</h2>
-            <hr>
             <table class="table">
               <tbody>
               <% @results.records.each do |result| %>

--- a/public/views/subjects/show.html.erb
+++ b/public/views/subjects/show.html.erb
@@ -1,20 +1,19 @@
 <main id="skip-header-target" role="main">
   <section class="py-3 d-flex justify-content-center">
     <div class="container-fluid mx-3">
-      <!-- Top headings-->
-      <div class="row pb-2 justify-content-between">
-        <div class="col pl-7"><h2><%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %></h2></div>
-      </div>
-      <div class="row pb-2 justify-content-between hidden">
-        <!-- Page actions probably not needed for subjects-->
-        <div class="col"><%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath } %></div>
-      </div>
-      <div class="row pb-1 justify-content-between">
-        <div class="col pl-7"><span class="inline-label clear"><strong><%= t('enumeration_names.subject_source') %></strong>: </span><%= t("enumerations.subject_source.#{@result['json']['source']}" ) %></div>
-      </div>
+      <div class="col">
+        <!-- Top headings-->
+        <div class="row pb-1 justify-content-between">
+          <div class="col pl-6"><h2><%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %></h2></div>
+        </div>
+        <div class="row pb-1 justify-content-between hidden">
+          <!-- Page actions probably not needed for subjects-->
+          <div class="col"><%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath } %></div>
+        </div>
+        <div class="row pb-1 justify-content-between">
+          <div class="col pl-6"><span class="inline-label clear"><strong><%= t('enumeration_names.subject_source') %></strong>: </span><%= t("enumerations.subject_source.#{@result['json']['source']}" ) %></div>
+        </div>
 
-      <!-- This section is probably not needed for subjects -->
-      <div>
         <% if !@result.dates.blank? %>
           <% render partial: 'shared/dates', locals: {:dates => @result.dates} %>
         <% end %>
@@ -26,8 +25,12 @@
           <span class='ref_id'>[Ref. ID: <%= @result['json']['ref_id'] %>]</span>
         <% end %>
         <% if @result['json']['scope_note'].present? %>
-          <span class="inline-label"><%= t('scope_note') %>
-            :</span> <%= process_mixed_content(@result['json']['scope_note']).html_safe %>
+          <div class="row pb-1 justify-content-between">
+            <div class="col pl-6">
+              <span class="inline-label"><strong><%= t('scope_note') %>
+                : </strong></span> <%= process_mixed_content(@result['json']['scope_note']).html_safe %>
+            </div>
+          </div>
         <% end %>
         <%= render partial: 'shared/display_notes' %>
       </div>
@@ -53,7 +56,7 @@
         <div class="col-3">
           <h3><%= t('more_about') %> '<%= @result.display_string %>'</h3>
 
-          <div class="acc_holder clear" >
+          <div class="acc_holder clear">
             <div class="accordion-group" role="tablist" id="accordion-01">
               <% if !(terms = ASUtils.wrap(@result['json']['terms'])).empty? %>
                 <% x = render partial: 'subjects/terms', locals: {:terms =>  terms, :list_clss => 'terms'} %>
@@ -69,7 +72,7 @@
           <br>
 
           <div id="subject-facets" <% if @facets.blank? %>class="hidden"<% end %>>
-            <h2 class="h4">Additional filters:</h2>
+            <h2 class="h4">Filter by:</h2>
             <div class="bg-light p-3">
               <%= render partial: 'subjects/only_facets' %>
             </div>


### PR DESCRIPTION
Changes:
- Redesigns the view subject page to follow nyc-core-framework styles. Also based on search results design.
- Fixes the duplication bug in the global search when using more than one search term in advanced search.