### PR TITLE
AB#10 - Collections page design changes

### DIFF
--- a/public/assets/javascripts/largetree.js.erb
+++ b/public/assets/javascripts/largetree.js.erb
@@ -739,16 +739,14 @@
                 row.css('height','auto')
                 var title = row.find('.title');
                 var strippedTitle = $("<div>").html(node.title).text();
-                title.append($('<a class="record-title" />').prop('href', TreeIds.link_url(node.uri)).text(node.title));
+                title.append($('<a class="record-title" />').prop('href', TreeIds.link_url(node.uri)).text(node.title)).addClass('text-justify');
                 title.attr('title', strippedTitle);
 
                 var ex = row.find('.expandme');
                 ex.attr('aria-label', 'expand element');
                 if (node.child_count === 0) {
-//                    ex.css('visibility', 'hidden');
-                    row.css('color','black');
-                    ex.attr('aria-hidden', 'true');
-                    ex.css('padding-left','10px');
+                    row.find('.record-title').addClass('p-1');
+                    row.find('.indentor').remove();
                 }
 
                 self.renderer.add_node_columns(row, node);

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -50,3 +50,5 @@ en:
     op_first_row:
       NOT: Not
     results_head: "%{start} - %{end} of %{total} %{type}"
+  actions:
+    collection_overview: Overview

--- a/public/views/resources/_agents_list.html.erb
+++ b/public/views/resources/_agents_list.html.erb
@@ -1,6 +1,12 @@
 <% list.each do |role, relationships| %>
+  <h4 class="pt-1">
+    <% if role=='creator'&& relationships.count>1%>
+      Creators
+      <% else %>
+    <%= I18n.t("enumerations.linked_agent_role.#{role}", :default => role) %>
+      <% end %>
+      </h4>
 
-  <h4 class="pt-1"><%= I18n.t("enumerations.linked_agent_role.#{role}", :default => role) %></h4>
   <ul class="present_list agents_list">
 
     <% relationships.each do |relationship| %>

--- a/public/views/resources/_idbadge.html.erb
+++ b/public/views/resources/_idbadge.html.erb
@@ -49,7 +49,6 @@ end
     </div>
   <% else %>
     <%== result.display_string %>
-    <small><%=t('resource._singular') %> <%= @result.ead_id %></small>
   <% end %>
 </h2>
 
@@ -57,6 +56,6 @@ end
   c.fetch('breadcrumb').each do |crumb, i|
      crumb_uri = crumb.fetch(:uri)
        crumb_uri = c.fetch('uri') if crumb_uri.blank? %>
-    <p class="mb-1"><%= link_to crumb.fetch(:crumb), app_prefix(crumb_uri),class: 'description' %></p>
+    <p class="mb-1"><%=t('resource._singular') %> <%= @result.ead_id %> - <%= link_to crumb.fetch(:crumb), app_prefix(crumb_uri),class: 'description' %></p>
   <%end
 end %>

--- a/public/views/resources/_infinite_idbadge.html.erb
+++ b/public/views/resources/_infinite_idbadge.html.erb
@@ -50,7 +50,7 @@
         <%if indent_level!= 0 %>
           <% comp_id = display_component_id(result, props.fetch(:infinite_item, false)) %>
           <% unless comp_id.blank? %>
-            <%= badge_label %> <%=comp_id %> :
+            <%= badge_label %> <%=comp_id %>:
           <% end %>
         <% end %>
         <%== props.fetch(:infinite_item, false) ? result.parse_full_title(true) : result.display_string %>

--- a/public/views/resources/_infinite_item.html.erb
+++ b/public/views/resources/_infinite_item.html.erb
@@ -19,7 +19,7 @@
   <% if indent_level < 2 %>
     <div class="row pt-2">
       <% unless @result.extents.blank? || all_inherited?(@result.extents) %>
-        <div class="col-lg-9">
+        <div class="col-lg-6">
           <h5><%= t('resource._public.extent') %></h5>
           <% @result.extents.each do |extent| %>
             <p>
@@ -31,7 +31,7 @@
       <% end %>
 
       <% unless @result.dates.blank? || all_inherited?(@result.dates) %>
-        <div class="col-lg-3">
+        <div class="col-lg-6">
           <h5><%= t('resource._public.dates') %></h5>
             <% @result.dates.each do |date| %>
             <p>
@@ -44,7 +44,7 @@
     </div>
   <%end %>
 
-  <div class="row pt-2">
+  <div  class="row pt-2">
     <div class="col-lg">
       <% unless @result.agents.blank? || all_inherited?(@result.agents.collect(&:last).flatten) %>
         <h5>Creators</h5>
@@ -61,6 +61,7 @@
   </div>
 
   <%if indent_level==1 %>
-    <h5 class="pb-2">Contents</h5>
+    <h5 class="pb-2" class="content">Contents</h5>
   <%end %>
 </div>
+

--- a/public/views/resources/_subject_list.html.erb
+++ b/public/views/resources/_subject_list.html.erb
@@ -3,7 +3,7 @@
   <!--      Handling subjects-->
   <%if !item['terms'].nil? %>
     <%item['terms'].take(1).each do |t_type|%>
-      <%subjects_list[t_type['term_type']] << [t_type['term'],item['uri']]%>
+      <%subjects_list[t_type['term_type']] << [item['title'],item['uri']]%>
     <% end %>
 <!--        Handling Names listed as subjects(Agent links)-->
   <% else %>


### PR DESCRIPTION
-- Moved Collection number to next line
-- Removed whitespace from title in Collection Organization nodes
--Changed Collection Overview to Overview in tabs
--Changed Creator to Creators in Overview
-- Fixed incomplete subject names in Overview
--Removed glyphicon for collections with no children
-- Fixed date column size in Collection Organization tab