### PR TITLE
AB#12 - Record groups search page design

### DIFF
--- a/public/assets/javascripts/nyc-core-framework.js
+++ b/public/assets/javascripts/nyc-core-framework.js
@@ -151,8 +151,46 @@ $('#collection_year').click(function(){
     else {
         $("#sort option[value='year_sort desc']").attr("selected", "selected");
         $("#sort option[value='year_sort asc']").removeAttr("selected");
-        $("#year-sort-icon").attr("class","fa fa-lg fa-caret-down");
+        $("#year-sort-icon").attr("class", "fa fa-lg fa-caret-down");
         $("#sort_form").submit();
-
     }
+    });
+
+    // Display classifications in ascending/descending order
+    $('#classification_title').click(function(){
+        var isSelected = $("#sort option[value='title_sort desc']").attr("selected");
+        //Sort classifications by title in ascending order
+        if (typeof isSelected !== typeof undefined && isSelected !== false)
+        {
+            $("#sort option[value='title_sort asc']").attr("selected","selected");
+            $("#sort option[value='title_sort desc']").removeAttr("selected");
+            $("#sort_form").submit();
+        }
+        //Sort classifications by title in descending order
+        else
+        {
+            $("#sort option[value='title_sort desc']").attr("selected","selected");
+            $("#sort option[value='title_sort asc']").removeAttr("selected");
+            $("#sort_form").submit();
+        }
+    });
+//Sort classifications by identifier in descending order
+    $('#classification_id').click(function(){
+        var isSelected = $("#sort option[value='identifier_sort desc, repo_sort desc, title_sort desc']").attr("selected");
+        //Sort classifications by identifiers in ascending order
+
+        if (typeof isSelected !== typeof undefined && isSelected !== false) {
+            $("#sort option[value='identifier_sort asc, repo_sort asc, title_sort asc']").attr("selected", "selected");
+            $("#sort option[value='identifier_sort desc, repo_sort desc, title_sort desc']").removeAttr("selected");
+            $("#sort_form").submit();
+            //$("#-sort-icon").attr("class","fa fa-lg fa-caret-up");
+        }
+        //Sort classifications by identifier in descending order
+        else {
+            $("#sort option[value='identifier_sort desc, repo_sort desc, title_sort desc']").attr("selected", "selected");
+            $("#sort option[value='identifier_sort asc, repo_sort asc, title_sort asc']").removeAttr("selected");
+           // $("#year-sort-icon").attr("class","fa fa-lg fa-caret-down");
+            $("#sort_form").submit();
+
+        }
 });

--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -343,4 +343,66 @@ Rails.application.config.after_initialize do
     end
 
   end
+
+  class ClassificationsController
+    def index
+      repo_id = params.fetch(:rid, nil)
+      if !params.fetch(:q, nil)
+        DEFAULT_CL_SEARCH_PARAMS.each do |k,v|
+          params[k] = v
+        end
+      end
+      search_opts = default_search_opts( DEFAULT_CL_SEARCH_OPTS)
+      search_opts['fq'] = ["repository:\"/repositories/#{repo_id}\""] if repo_id
+
+      @base_search = repo_id ? "repositories/#{repo_id}/classifications?" : '/classifications?'
+      page = Integer(params.fetch(:page, "1"))
+
+      begin
+        set_up_and_run_search( DEFAULT_CL_TYPES, DEFAULT_CL_FACET_TYPES, search_opts, params)
+      rescue NoResultsError
+        flash[:error] = I18n.t('search_results.no_results')
+        redirect_back(fallback_location: '/') and return
+      rescue Exception => error
+        flash[:error] = I18n.t('errors.unexpected_error')
+        redirect_back(fallback_location: '/') and return
+      end
+
+      if @results['total_hits'] > 1
+        @search[:dates_within] = true if params.fetch(:filter_from_year,'').blank? && params.fetch(:filter_to_year,'').blank?
+        @search[:text_within] = true
+      end
+      @sort_opts = []
+      @sort_opts << [
+          I18n.t('search_sorting.sorting', :type => I18n.t("search_sorting.classification_identifier"), :direction => I18n.t("search_sorting.asc")),
+          IDENTIFIER_SORT_ASC
+      ]
+      @sort_opts << [
+          I18n.t('search_sorting.sorting', :type => I18n.t("search_sorting.classification_identifier"), :direction => I18n.t("search_sorting.desc")),
+          IDENTIFIER_SORT_DESC
+      ]
+      all_sorts = Search.get_sort_opts
+      all_sorts.delete('relevance') unless params[:q].size > 1 || params[:q] != '*'
+      all_sorts.keys.each do |type|
+        next if type == 'year_sort'
+        @sort_opts.push(all_sorts[type])
+      end
+      @page_title = I18n.t('classification._plural')
+      @results_type = @page_title
+      @no_statement = true
+      # Updated the view
+      render 'classifications/search_results'
+
+    end
+
+    #Method to fetch raw data for classification terms
+    def term_json
+      begin
+        uri = "/repositories/#{params[:rid]}/classification_terms/#{params[:id]}"
+        render json: archivesspace.get_raw_record(uri)
+      rescue RecordNotFound
+        record_not_found(uri, 'classification_term')
+      end
+    end
+  end
 end

--- a/public/views/classifications/_idbadge.html.erb
+++ b/public/views/classifications/_idbadge.html.erb
@@ -1,0 +1,49 @@
+<%
+if result.level
+    if result.primary_type =~ /digital_object/
+      level = I18n.t("enumerations.digital_object_level.#{result.level}", :default => result.level)
+      badge_label = I18n.t("digital_object._public.badge_label", :level => level)
+    else
+      level = result.level == 'otherlevel' ? result.other_level : result.level
+      badge_label = I18n.t("enumerations.archival_record_level.#{level}", :default => level)
+    end
+else
+    badge_label = t("#{result.primary_type}._singular")
+end
+%>
+
+<%# build URL with slugs depending on the primary type %>
+<% case result.primary_type %>
+  <% when "resource" %>
+    <% url = resource_base_url(result) %>
+  <% when "archival_object" %>
+    <% url = archival_object_base_url(result) %>
+  <% when "digital_object" %>
+    <% url = digital_object_base_url(result) %>
+  <% when "accession" %>
+    <% url = accession_base_url(result) %>
+  <% when "subject" %>
+    <% url = subject_base_url(result) %>
+  <% when "classification" %>
+    <% url = classification_base_url(result) %>
+  <% when "agent_person" %>
+    <% url = agent_base_url(result) %>
+  <% when "agent_family" %>
+    <% url = agent_base_url(result) %>
+  <% when "agent_corporate_entity" %>
+    <% url = agent_base_url(result) %>
+  <% when "agent_software" %>
+    <% url = agent_base_url(result) %>
+  <% else %>
+    <% url = result.uri %>
+<% end %>
+
+<%= (props.fetch(:full,false)? '<h1>' : '<h3>').html_safe %>
+  <% if !props.fetch(:full,false) %>
+    <div class="card m-2 mb-0">
+        <%== props.fetch(:infinite_item, false) ? result.parse_full_title(true) : result.display_string %>
+    </div>
+  <% else %>
+    <%== result.display_string %>
+  <% end %>
+<%= (props.fetch(:full,false)? '</h1>' : '</h3>').html_safe %>

--- a/public/views/classifications/_result.html.erb
+++ b/public/views/classifications/_result.html.erb
@@ -1,0 +1,287 @@
+ <%# any result that is going to be presented in a list %>
+ <%# Pry::ColorPrinter.pp(result['json'])%>
+<%linked_records_types = Hash.new{|hash, key| hash[key] = Array.new{Hash.new}} %>
+<tr id="recordrow-<%=result['json']['identifier'].parameterize.underscore%>">
+  <td>
+    <% if !props.fetch(:full,false) %>
+
+      <div class="recordrow pb-2" style="clear:both" data-uri="<%= result.uri %>">
+
+    <% end %>
+    <%= render partial: 'classifications/idbadge', locals: {:result => result, :props => props } %>
+
+    <div class="recordsummary description pl-2" style="clear:both">
+      <% if !result['parent_institution_name'].blank? %>
+
+       <div>
+         <strong><%= t('parent_inst') %>:</strong>
+         <%= result['parent_institution_name'] %>
+       </div>
+
+      <% end %>
+      <!--   Design for linked records for classifications-->
+      <% if !result['json']['linked_records'].empty? %>
+
+        <% result['json']['linked_records'].each do |linked_record|%>
+          <% linked_records_types[linked_record['_resolved']['jsonmodel_type']]<<linked_record %>
+        <% end %>
+
+        <% linked_records_types.each do |rec_type,rec| %>
+
+         <div class="accordion-group ml-2 mb-2 col-sm" role="tablist" id="accordion-<%=index %>-<%=rec_type %>">
+           <div class="card">
+             <a class="card-header bg-white collapse collapsed" id="acc-button-<%=index %>-<%=rec_type %>" data-toggle="collapse" href="#panel-acc-button-<%=index %>-<%=rec_type %>" role="tab" aria-expanded="false" aria-controls="panel-acc-button-<%=index %>-<%=rec_type %>">
+               <span class="title" role="heading" aria-level="3"><%=rec.length %> Related <%=rec_type.pluralize.capitalize() %></span>
+             </a>
+
+             <div class="bg-white collapse " id="panel-acc-button-<%=index %>-<%=rec_type %>" role="tabpanel" aria-labelledby="acc-button-<%=index %>-<%=rec_type %>" data-parent="#accordion-<%=index %>-<%=rec_type %>" style="">
+               <div class="card-body">
+                 <table class="table pl-2">
+                   <tbody>
+                   <% rec.each do |linked_record|%>
+                     <tr>
+                       <td>
+                         <a href="<%=linked_record['ref'] %>"><%=linked_record['_resolved']['title'] %></a>
+                         <small>
+                           <%=rec_type.capitalize%>
+                           <% i=0
+                              loop do
+                           %>
+                             <%=linked_record['_resolved']['id_'+i.to_s]%>
+                             <% i=i+1
+                             if linked_record['_resolved']['id_'+i.to_s].blank?
+                               break
+                             else %>
+                               -
+                             <% end
+                              end %>
+                         </small>
+                       </td>
+                     </tr>
+                   <% end %>
+                   </tbody>
+                 </table>
+               </div>
+             </div>
+           </div>
+         </div>
+      <% end %>
+     <% end %>
+
+   <% note_struct = result.note('abstract')
+	  if note_struct.blank?
+	    note_struct = result.note('scopecontent')
+          end
+	  if !note_struct['note_text'].blank? %>
+      <div class="abstract single_note"><span class='inline-label'><b><%= note_struct['label'] %></b></span>
+        <% unless note_struct['is_inherited'].blank? %>
+          <%= inheritance(note_struct['is_inherited']).html_safe %>
+        <% end %>
+        <% if note_struct['note_text'].length > AppConfig[:abstract_note_length] %>
+           <% truncated_note = note_struct['note_text'][0..AppConfig[:abstract_note_length]-1] %>
+           <% end_index = truncated_note.rindex(' ') || AppConfig[:abstract_note_length]-1 %>
+           <%= (strip_tags(truncated_note[0..end_index - 1]) + '...').html_safe %>
+        <% else %>
+	        <%= note_struct['note_text'].html_safe %>
+        <% end %>
+      </div>
+    <% end %>
+   <% unless props.fetch(:no_repo, false) %>
+     <% r_uri = nil
+        r_name = nil
+        if result['json']['repository'] && result['json']['repository']['_resolved'] && (!result['json']['repository']['ref'].blank? || !result['json']['repository']['_resolved']['name'].blank?)
+          r_uri = result['json']['repository']['ref'] || ''
+          r_name = result['json']['repository']['_resolved']['name'] || ''
+        elsif result['_resolved_repository'] && result['_resolved_repository']['json']
+          r_uri =  result['_resolved_repository']['json']['uri'] || ''
+          r_name = result['_resolved_repository']['json']['name'] || ''
+        end
+     %>
+   <% end %>
+
+    <% if result['json'].has_key?('dates') || result['json'].has_key?('dates_of_existence') %>
+      <div class="dates">
+        <% dates = (result['json']['dates'] || result['json']['dates_of_existence']
+        ).collect {|date| parse_date(date)}.reject{|label, expression| expression.blank?} %>
+        <% unless dates.empty? %>
+          <strong><%= t('dates') %>: </strong>
+        <% end %>
+        <%= dates.collect {|label, expression| label.blank? ? expression : "#{label}#{expression}"}.join('; ') %>
+      </div>
+    <% end %>
+
+
+
+     <% if !props.fetch(:full,false)  && result['primary_type'] == 'repository' %>
+       <div><strong><%= t('number_of', { :type => t('resource._plural') }) %></strong> <%= @counts[result.uri]['resource'] %></div>
+    <% end %>
+
+     <% if result.primary_type == 'classification' && result.classification_terms? %>
+       <div>
+         <ul class="subgroups-list" id ="<%=result['json']['identifier'] %>-subgroup">
+         </ul>
+       </div>
+     <% end %>
+   </div>
+
+  <% if !props.fetch(:full,false) %>
+    </div>
+  <% end %>
+  </td>
+  <td class="w-20 text-center">
+    <%=result['json']['identifier'] %>
+  </td>
+</tr>
+<script type="text/javascript">
+
+    $.ajax({
+            url: "<%=result['json']['uri']%>/tree/root",
+            type: 'GET',
+            dataType: 'json',
+            success: function (data) {
+
+                var total_child_linked_records=0;
+                //Checking if there are sub-groups for parent(record group)
+                if (data['child_count'] > 0) {
+                    var waypoints = data['precomputed_waypoints'];
+                    for (singleWaypoint in waypoints) {
+
+                        var waypointNodes = waypoints[singleWaypoint];
+
+                        for (waypointNode in waypointNodes) {
+                            var nodesData = waypointNodes[waypointNode];
+
+                            for(nodeData in nodesData) {
+
+                                $.ajax({
+                                    //Fetching json data for each of the sub-group
+                                    url: nodesData[nodeData]['uri']+"/json",
+                                    type: 'GET',
+                                    dataType: 'json',
+                                    success: function (info) {
+
+                                        if(info['linked_records'].length>0) {
+                                            //Calculating the total linked records for subgroups
+                                            total_child_linked_records += info['linked_records'].length;
+                                            //Removing whitespace and '.' from identifier
+                                            var subgroup = document.getElementById("<%=result['json']['identifier']%>-subgroup");
+                                            var identifier = info['identifier'].replace(" ", "-");
+                                            identifier = identifier.replace(".", "-");
+                                            //indexes for collection linked records
+                                            var collection_idxs = [];
+                                            //indexes for accession linked records
+                                            var accessions_idxs = [];
+                                            //Separating the indexes for collection linked records and accesssion linked records
+                                            for (i = 0; i < info['linked_records'].length; i++) {
+
+                                                if (info['linked_records'][i]['_resolved']['jsonmodel_type'] == "resource") {
+                                                    collection_idxs.push(i);
+                                                } else {
+                                                    accessions_idxs.push(i);
+                                                }
+                                            }
+                                            subgroup.innerHTML += "<li class='pt-1'><h5> Subgroup " + info['identifier'] + " " + info['title'] + "</h5>\n";
+                                            //Creating accordion for collection linked records
+                                            if (collection_idxs.length > 0) {
+                                                <% comp_id = display_component_id(result, props.fetch(:infinite_item, false)) %>
+
+                                                var content = "<div class=\"accordion-group  ml-2 col-sm\" role=\"tablist\" id=\"accordion-" + identifier + "-resource\">\n" +
+                                                    "<div class=\"card\">\n" +
+                                                    "<a class=\"card-header bg-white collapse collapsed\" id=\"acc-button-" + identifier + "-resource\" data-toggle=\"collapse\" href=\"#panel-acc-button-" + identifier + "-resource\" role=\"tab\" aria-expanded=\"false\" aria-controls=\"panel-acc-button-" + identifier + "-resource\">\n" +
+                                                    "<span class=\"title\" role=\"heading\" aria-level=\"3\">" + collection_idxs.length + " Related Collections</span>\n" +
+                                                    "</a>\n" +
+                                                    "<div class=\"collapse bg-white\" id=\"panel-acc-button-" + identifier + "-resource\" role=\"tabpanel\" aria-labelledby=\"acc-button-" + identifier + "-resource\" data-parent=\"#accordion-" + identifier + "-resource\">\n" +
+                                                    "<div class=\"card-body\">\n" +
+                                                    "<table class=\"table pl-2\">\n" +
+                                                    "<tbody>";
+
+
+                                                collection_idxs.forEach(function (i) {
+
+                                                    content += "<tr><td><a href=\"" + info['linked_records'][i]['ref'] + "\">" + info['linked_records'][i]['_resolved']['title'] + "</a><small> Collection ";
+                                                    var j=0;
+                                                    while(typeof info['linked_records'][i]['_resolved']['id_'+j] != 'undefined') {
+                                                        content += info['linked_records'][i]['_resolved']['id_'+j]+"-";
+                                                        j++;
+                                                    }
+                                                    //Removing extra '-' at the end of identifier
+                                                    content = content.slice(0,-1);
+                                                    content+= "</small></tr></td>";
+
+
+                                                });
+
+                                                content += " </tbody>\n" +
+                                                    "</table>\n" +
+                                                    "</div>\n" +
+                                                    "</div><!-- .collapse -->\n" +
+                                                    "</div><!-- .card-->\n" +
+                                                    "</div></li>";
+                                                //Appeding accordion to subgroup div
+                                                subgroup.innerHTML += content;
+                                            }
+                                            if (accessions_idxs.length > 0) {
+
+                                                var content = "<div class=\"accordion-group  ml-2 col-sm\" role=\"tablist\" id=\"accordion-" + identifier + "-classification\">\n" +
+                                                    "<div class=\"card\">\n" +
+                                                    "<a class=\"card-header bg-white collapse collapsed\" id=\"acc-button-" + identifier + "-classification\" data-toggle=\"collapse\" href=\"#panel-acc-button-" + identifier + "-classification\" role=\"tab\" aria-expanded=\"false\" aria-controls=\"panel-acc-button-" + identifier + "-classification\">\n" +
+                                                    "<span class=\"title\" role=\"heading\" aria-level=\"3\">" + accessions_idxs.length + " Related Accessions</span>\n" +
+                                                    "</a>\n" +
+                                                    "<div class=\"collapse bg-white\" id=\"panel-acc-button-" + identifier + "-classification\" role=\"tabpanel\" aria-labelledby=\"acc-button-" + identifier + "-classification\" data-parent=\"#accordion-" + identifier + "-classification\">\n" +
+                                                    "<div class=\"card-body\">\n" +
+                                                    "<table class=\"table pl-2\">\n" +
+                                                    "<tbody>";
+
+                                                accessions_idxs.forEach(function (i) {
+
+                                                    content += "<tr><td><a href=\"" + info['linked_records'][i]['ref'] + "\">" + info['linked_records'][i]['_resolved']['title'] + "</a><small> Accession ";
+                                                    var j=0;
+                                                    while(typeof info['linked_records'][i]['_resolved']['id_'+j] != 'undefined') {
+                                                        content += info['linked_records'][i]['_resolved']['id_'+j]+"-";
+                                                        j++;
+                                                    }
+                                                    content = content.slice(0,-1);
+                                                    content+= "</small></tr></td>";
+
+
+                                                });
+
+                                                content += " </tbody>\n" +
+                                                    "  </table>\n" +
+                                                    " </div>\n" +
+                                                    "</div><!-- .collapse -->\n" +
+                                                    "</div><!-- .card -->\n" +
+                                                    " </div></li>";
+
+                                                subgroup.innerHTML += content;
+                                            }
+                                        }
+
+                                    },
+                                    async: false
+
+                                });
+
+                            }
+                        }
+
+                    }
+                    //Removing parent(record-group) if no sub-group linked records and no parent linked records
+                    if(total_child_linked_records ==0 && <%=result['json']['linked_records'].empty? %>){
+                        $("#recordrow-<%=result['json']['identifier'].parameterize.underscore %>").remove();
+                    }
+
+
+                }
+                //Removing parent if there is no sub-group and parent has no linked records
+                else {
+                    if(<%=result['json']['linked_records'].empty? %>)
+                    $("#recordrow-<%=result['json']['identifier'].parameterize.underscore %>").remove();
+                }
+
+            },
+
+        }
+
+    );
+</script>

--- a/public/views/classifications/search_results.html.erb
+++ b/public/views/classifications/search_results.html.erb
@@ -1,0 +1,57 @@
+<% results_type = (defined?(@results_type) ? @results_type : t('search_results.results')) %>
+
+<div class="row">
+  <div class="col-sm-12">
+    <%= render partial: 'shared/breadcrumbs' %>
+  </div>
+</div>
+<% if defined?(@results) %>
+  <div class="row" style = "display: none">
+    <div class="col-sm-9">
+      <a name="main" title="<%= t('internal_links.main') %>"></a>
+      <%= render partial: 'shared/sorter' %>
+    </div>
+  </div>
+
+  <main id="skip-header-target" role="main">
+    <section class="py-3 d-flex justify-content-center">
+      <div class="container-fluid mx-6" >
+        <div class="row matrix-gutter">
+          <h2 class="pl-1 pb-1">
+            Record Groups
+          </h2>
+          <table class="table">
+            <thead>
+              <tr id="classifications_header">
+                <th scope="col" id="classification_title" >Record Group Title &nbsp
+                  <span id="classification-caret"
+                    <% if params[:sort] == "title_sort desc" %>
+                        class="fa fa-lg fa-caret-down"
+                    <% else %>
+                        class="fa fa-lg fa-caret-up"
+                    <% end %>>
+                  </span>
+                </th>
+                <th class="w-20 text-center" scope="col" id="classification_id">Identifier &nbsp
+                  <span id="id-caret"
+                    <% if params[:sort] == "identifier_sort desc"%>
+                      class="fa fa-lg fa-caret-down"
+                    <% else %>
+                        class="fa fa-lg fa-caret-up"
+                    <% end %>>
+                  </span>
+              </tr>
+            </thead>
+            <tbody>
+              <% @results.records.each_with_index do  |result,index |  %>
+                <p><%=result['json']['level'] %></p>
+                  <%= render partial: 'classifications/result', locals: {:result => result, :index=>index,:props => (@result_props || {}).merge({:full => false})} %>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  </main>
+
+<% end %>


### PR DESCRIPTION
- Redesigned records group page to conform to nyc-core-framework design
- Add accordion listing the collections and accessions for record groups and sub-groups
- Removed sub-groups with no linked records
- Removed record groups with no sub-groups and no linked records
- Removed record groups with all sub-groups having no linked records and record group having no linked records
- Added sorting based on record group title and identifier
- Removed links to individual record group and sub-group pages