### PR TITLE
AB#618 - Final Collection Organization Tab Fixes

### DIFF
--- a/public/assets/javascripts/largetree.js.erb
+++ b/public/assets/javascripts/largetree.js.erb
@@ -442,6 +442,8 @@
         var self = this;
         var button = row.find('.expandme');
 
+        $(button).removeClass('fa-chevron-right');
+        $(button).addClass('fa-chevron-down');
         if (button.data('expanded')) {
             if (done_callback) {
                 done_callback();
@@ -478,6 +480,8 @@
 
         var button = row.find('.expandme');
 
+        $(button).removeClass('fa-chevron-down');
+        $(button).addClass('fa-chevron-right');
         $(button).data('expanded', false);
         button.find('.expandme-icon').removeClass('expanded');
 
@@ -763,18 +767,18 @@
                 row.data('child_count', node.child_count);
                 row.css('height','auto')
                 var title = row.find('.title');
-                title.addClass("pl-"+level);
+                title.addClass("pl-"+(level+1));
                 title.addClass("pr-1");
                 var strippedTitle = $("<div>").html(node.title).text();
                 title.append("<span class=\"id-badge text-dark\"></span>");
-                title.append($('<a class="record-title" />').prop('href', TreeIds.link_url(node.uri)).text(node.title)).addClass('text-justify');
+                title.append($('<a class="record-title" />').prop('href', TreeIds.link_url(node.uri)).text(node.title));
 
                 title.attr('title', strippedTitle);
 
                 var ex = row.find('.expandme');
                 ex.attr('aria-label', 'expand element');
                 if (node.child_count === 0) {
-                    row.find('.record-title').addClass('p-1');
+                    row.find('.record-title').addClass('py-1');
                     row.find('.indentor').remove();
                 }
 

--- a/public/assets/javascripts/treeview.js.erb
+++ b/public/assets/javascripts/treeview.js.erb
@@ -23,8 +23,8 @@ $.fn.extend({
             branch.addClass('branch');
             branch.on('click', function (e) {
                 if (this == e.target) {
-                    var icon = $(this).children('i:first');
-                    icon.toggleClass(openedClass + " " + closedClass);
+                    var icon = $(this).children('span:first');
+                    icon.toggleClass(openedClass+" "+closedClass);
                     $(this).children().children().toggle();
                 }
             })

--- a/public/views/objects/_idbadge.html.erb
+++ b/public/views/objects/_idbadge.html.erb
@@ -54,7 +54,7 @@
 <div class="badge-and-identifier mb-1">
   <%if !result['json'].has_key?("component_id_inherited") %><a href="<%=url%>"> <% end %>
   <div class="record-type-badge <%= (result.primary_type.start_with?('agent') ? 'agent' : result.primary_type) %> d-inline-block <%if result['json'].has_key?("component_id_inherited") %>mr-1<% end %>">
-    <i class="<%= icon_for_type(result.primary_type) %>"></i>&#160;<%= badge_label %><% if result.container_summary_for_badge %> &mdash; <%= result.container_summary_for_badge %> <% else %>:<% end %>
+    <i class="<%= icon_for_type(result.primary_type) %>"></i><% if result.container_summary_for_badge %> <%= result.container_summary_for_badge %> <% else %>&#160;<%= badge_label %>:<% end %>
   </div>
   <% comp_id = display_component_id(result, props.fetch(:infinite_item, false)) %>
   <% unless comp_id.blank? %>

--- a/public/views/resources/infinite.html.erb
+++ b/public/views/resources/infinite.html.erb
@@ -83,7 +83,7 @@
 <script>
 
 // Constructing sidebar tree
-$('#sidebar-tree').treed();
+$('#sidebar-tree').treed({openedClass : 'fa fa-chevron-down', closedClass : 'fa fa-chevron-right'});
 
 //Displaying the main record on page load
 $.ajax({


### PR DESCRIPTION
-- Toggle icon between fa-chevron-down and fa-chevron-right for open and closed element in sidebar
--Removed 'File-' for file level element identifiers in sidebar and left panel in collection organization tab
--Removed 'File-' from identifier in archival object page
-- Fixed indentation for child elements in sidebar 
-- Changed "Series:1" to "Series 1:" for identifiers  