### PR TITLE
AB#627 - Homepage text edits

### DIFF
--- a/public/views/shared/_appointment_banner.html.erb
+++ b/public/views/shared/_appointment_banner.html.erb
@@ -7,7 +7,7 @@
       </div>
       <div class="col-lg">
         <p>
-          Our collections are open for research. Contact us at research@records.nyc.gov for an appointment, and come visit us at 31 Chambers Street, New York, NY.
+          Our collections are open for research. Contact us at research@records.nyc.gov. Our research room at 31 Chambers Street is currently closed to the public.
         </p>
       </div>
       <!-- .col -->

--- a/public/views/welcome/show.html.erb
+++ b/public/views/welcome/show.html.erb
@@ -8,7 +8,7 @@
             <h1 class="card-title display-4 font-weight-bold">Welcome to the Municipal Archives</h1>
             <p class="card-text-bold" >The Archives preserves and makes available New York City government's historical records.
               Explore our collections dating from 1645 to the present including documents, digital collections, still and moving images,
-              ledgers and docket books, vital records, cartographic materials, blueprints, and audiovisual materials.</p>
+              ledgers and docket books, cartographic materials, blueprints, and audiovisual materials.</p>
           </div>
         </div>
       </div>
@@ -37,7 +37,7 @@
             <div class="card-body text-dark">
               <h2 class="card-title text-center">Subjects</h2>
               <p class="card-text">
-                Browse by topical subjects, material types, occupations, and location.
+                Browse by topical subjects, material types, occupations, and locations.
               </p>
             </div>
             <div class="card-footer text-center">
@@ -68,7 +68,7 @@
             <div class="card-body text-white">
               <h2 class="card-title text-center">Record Groups</h2>
               <p class="card-text">
-                The collections are organized by Record Group, typically the creating city agency.
+                Our collections and accessions are organized by Record Group, typically the creating city agency.
               </p>
             </div>
             <div class="card-footer text-center">


### PR DESCRIPTION
-Removed "vital records" from description in "Welcome to the Municipal Archives"
-Updated research appointment section to "Our collections are open for research. Contact us at research@records.nyc.gov. Our research room at 31 Chambers Street is currently closed to the public."
- updated Record Groups section to "Our collections and accessions are organized by Record Group, typically the creating city agency."
-Added "s" to "location" in subjects section