### PR TITLE
AB#630 - Footer Update

### DIFF
--- a/public/views/shared/_footer.html.erb
+++ b/public/views/shared/_footer.html.erb
@@ -65,9 +65,11 @@
             <div class="col-lg mb-3 mb-lg-0">
               <ul class="extensible-list">
                 <li>
-                  <a class="text-reset" href="mailto:research@records.nyc.gov">
-                    <strong>Contact Us:<br>research@records.nyc.gov</strong>
-                  </a>
+                  <strong>Contact Us:
+                    <a class="text-reset" href="mailto:research@records.nyc.gov">
+                      <br>research@records.nyc.gov
+                    </a>
+                  </strong>
                 </li><br>
                 <li>
                   <a class="text-reset" href="https://twitter.com/nycrecords">
@@ -81,9 +83,6 @@
                   </a>
                   <a class="text-reset" href="http://www.youtube.com/nycdeptofrecords">
                     <span class="fab fa-lg fa-youtube-square"></span>&nbsp;
-                  </a>
-                  <a class="text-reset" href="http://nycrecords.tumblr.com/">
-                    <span class="fab fa-lg fa-tumblr-square"></span>&nbsp;
                   </a>
                 </li>
               </ul>


### PR DESCRIPTION
- Removed tumblr link from the footer
- Moved the text "Contact us" outside the hyperlink.