### PR TITLE
AB#642 - Final QA fixes

### DIFF
--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -50,6 +50,13 @@ en:
     op_first_row:
       NOT: Not
     results_head: "%{start} - %{end} of %{total} %{type}"
+    filter:
+      primary_type:
+        _singular: Type
+      subjects:
+        _singular: Subject
+      published_agents:
+        _singular: Name
   actions:
     collection_overview: Overview
 
@@ -64,3 +71,17 @@ en:
 
   errors:
     backend_down_message: ArchivesSpace is currently experiencing technical difficulties. We apologise for the inconvenience.
+
+  agent_person:
+    _plural: People
+
+  agent_family:
+    _plural: Families
+
+  agent_corporate_entity:
+    _plural: Organizations
+
+  agent_software:
+    _plural: Softwares
+
+

--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -321,7 +321,8 @@ Rails.application.config.after_initialize do
         end
 
         if raw_data.container_summary_for_badge
-          badge_label = raw_data.container_summary_for_badge
+          badge_label = raw_data.container_summary_for_badge.delete! ':'
+          badge_label += ':'
         end
 
         comp_id = display_component_id(raw_data,true)

--- a/public/views/agents/_related_agents.html.erb
+++ b/public/views/agents/_related_agents.html.erb
@@ -7,13 +7,21 @@
 %>
 
 <% grouped_relationships.each do |type, relationships| %>
-  <h4 class="h5"><%= I18n.t("#{type}._singular") %></h4>
+  <% agent_types=Hash.new { |h, k| h[k] = [] } %>
+  <h4 class="h5 pt-1"><%= I18n.t("#{type}._singular") %></h4>
   <ul class="present_list unstyled-list small">
-    <% relationships.each do |relationship| %>
-      <% agent = relationship['_resolved'] %>
+  <%
+    relationships.each do |relationship|
+      agent_types[relationship['_resolved']['jsonmodel_type']].push(relationship['_resolved'])
+    end
+  %>
+  <% agent_types.each do |agent_type,related_agents| %>
+    <b><%= I18n.t("#{agent_type}._plural") %></b>
+    <%related_agents.each do |agent| %>
       <li class="pb-1">
-        <%= link_to agent['display_name']['sort_name'], app_prefix(agent['uri']) %> - Related <%= I18n.t("#{agent['jsonmodel_type']}._singular") %>
+        <%= link_to agent['display_name']['sort_name'], app_prefix(agent['uri']) %>
       </li>
     <% end %>
+  <% end %>
   </ul>
 <% end %>

--- a/public/views/landing/resources/_only_facets.html.erb
+++ b/public/views/landing/resources/_only_facets.html.erb
@@ -66,7 +66,7 @@
              title = "Occupation"
              type="subjects"
            when "name_person"
-             title = "People"
+             title = "Person"
               type="published_agents"
            when "name_corporate_entity"
              title = "Organization"

--- a/public/views/objects/_idbadge.html.erb
+++ b/public/views/objects/_idbadge.html.erb
@@ -52,9 +52,9 @@
   <% end %>
 </h2>
 <div class="badge-and-identifier mb-1">
-  <%if !result['json'].has_key?("component_id_inherited") %><a href="<%=url%>"> <% end %>
+  <%if !result['json'].has_key?("component_id_inherited") %><a href="<%=url%>"><% end %>
   <div class="record-type-badge <%= (result.primary_type.start_with?('agent') ? 'agent' : result.primary_type) %> d-inline-block <%if result['json'].has_key?("component_id_inherited") %>mr-1<% end %>">
-    <i class="<%= icon_for_type(result.primary_type) %>"></i><% if result.container_summary_for_badge %> <%= result.container_summary_for_badge %> <% else %>&#160;<%= badge_label %>:<% end %>
+    <i class="<%= icon_for_type(result.primary_type) %>"></i><% if result.container_summary_for_badge %><%= result.container_summary_for_badge.delete! ':' %> <% else %><%= badge_label %>:<% end %>
   </div>
   <% comp_id = display_component_id(result, props.fetch(:infinite_item, false)) %>
   <% unless comp_id.blank? %>
@@ -63,7 +63,7 @@
         <b>
           <a href="<%=result['json']['component_id_inherited']['ref'] %>">
         <span class="id-label">
-            <%=result['json']['component_id_inherited']['level']%>:
+            <%=result['json']['component_id_inherited']['level']%>
         </span>
         <span class="component">
             <%= comp_id %>

--- a/public/views/objects/_record_innards.html.erb
+++ b/public/views/objects/_record_innards.html.erb
@@ -59,8 +59,6 @@
 		<% end %>
 	<% end %>
 
-
-
 	<div class ="pt-2">
 		<% (@result.notes["accessrestrict"] || []).each do |note_struct| %>
 			<% unless note_struct['note_text'].blank? %>
@@ -74,22 +72,18 @@
 		<p><%= @result.inventory %></p>
 	<% end %>
 
+
 	<% ASUtils.find_local_directories('public/views/_upper_record_innards.html.erb').each do |template| %>
 		<%= render :file => template if File.exists?(template) %>
 	<% end %>
 </div>
-
-<div class="acc_holder clear" >
-	<div class="panel-group" id="res_accordion">
+<div class="accordion-group my-3" role="tablist" id="accordion-01">
 		<% x = render partial: 'shared/multi_notes', locals: {:types => folder,:title_desc => '4'} %>
 		<% unless x.blank? %>
 			<%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('resource._public.additional'),
 																														 :p_id => 'add_desc', :p_body => x } %>
 		<% end %>
-		<% if @result.kind_of?(Accession) && !@result.deaccessions.blank? %>
-			<% x = render partial: 'shared/present_list', locals: {:list =>  @result.deaccessions.collect{|d| d.fetch('description')}, :list_clss => 'deaccessions'} %>
-			<%= render partial: 'shared/accordion_panel', locals: {:p_title => t('deaccessions'), :p_id => 'deaccessions_list', :p_body => x} %>
-		<% end %>
+
 		<% unless @result.subjects.blank? %>
 			<% x= render partial: 'shared/present_list', locals: {:list => @result.subjects, :list_clss => 'subjects_list'} %>
 			<%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('subject._plural'),
@@ -100,46 +94,18 @@
 			<%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('classification._plural'),
 																														 :p_id => 'classifications_list', :p_body => x} %>
 		<% end %>
-		<% unless @result.agents.blank? %>
-			<% x= render partial: 'shared/agents_list', locals: {:list => @result.agents} %>
-			<%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('pui_agent.related'),
-																														 :p_id => 'agent_list', :p_body => x} %>
-		<% end %>
-		<% unless @result.linked_digital_objects.blank? %>
+
+		<% unless @result.kind_of?(DigitalObject) || @result.linked_digital_objects.blank? %>
 			<% x = render partial: 'resources/linked_digital_objects', locals: {:digital_objects => @result.linked_digital_objects} %>
 			<%= render partial: 'shared/accordion_panel', locals: {:p_title => t('linked_digital_objects'), :p_id => 'linked_digital_objects_list', :p_body => x} %>
 		<% end %>
-		<% if @result.kind_of?(Resource) && !@result.finding_aid.blank? %>
-			<% x= render partial: 'resources/finding_aid' %>
-			<%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('resource._public.finding_aid.head'),
-																														 :p_id => 'fa', :p_body => x} %>
-		<% end %>
 
-		<% if @result.kind_of?(DigitalObject) && !@result.linked_instances.blank? %>
-			<% x = render partial: 'digital_objects/linked_instances', locals: {:instances => @result.linked_instances} %>
-			<%= render partial: 'shared/accordion_panel', locals: {:p_title => t('linked_instances'), :p_id => 'linked_instances_list', :p_body => x} %>
-		<% end %>
 		<% unless @result.external_documents.blank? %>
 			<% x = render partial: 'shared/present_list_external_docs', locals: {:list =>  @result.external_documents, :list_clss => 'external_docs'} %>
 			<%= render partial: 'shared/accordion_panel', locals: {:p_title => t('external_docs'), :p_id => 'ext_doc_list', :p_body => x} %>
 		<% end %>
-		<% unless @repo_info.blank? || @repo_info['top']['name'].blank? %>
-			<% x= render partial: 'repositories/repository_details' %>
-			<%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('repository.details'),
-																														 :p_id => 'repo_deets', :p_body => x} %>
-		<% end %>
-		<% if @result.kind_of?(Resource) && !@result.related_accessions.blank? %>
-			<% x = render partial: 'resources/related_accessions', locals: {:accessions => @result.related_accessions} %>
-			<%= render partial: 'shared/accordion_panel', locals: {:p_title => t('related_accessions'), :p_id => 'related_accessions_list', :p_body => x} %>
-		<% end %>
-		<% if @result.kind_of?(Accession) && !@result.related_resources.blank? %>
-			<% x = render partial: 'accessions/related_resources', locals: {:resources => @result.related_resources} %>
-			<%= render partial: 'shared/accordion_panel', locals: {:p_title => t('related_resources'), :p_id => 'related_resources_list', :p_body => x} %>
-		<% end %>
-	</div>
+
 	<% ASUtils.find_local_directories('public/views/_lower_record_innards.html.erb').each do |template| %>
 		<%= render :file => template if File.exists?(template) %>
 	<% end %>
 </div>
-<script type="text/javascript" >initialize_accordion(".note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>");
-</script>

--- a/public/views/objects/show.html.erb
+++ b/public/views/objects/show.html.erb
@@ -6,7 +6,9 @@
     </div>
 
   <div class="row" id="notes_row">
-    <%= render partial: 'shared/digital', locals: {:dig_objs => @dig} %>
+    <% if @result.kind_of?(DigitalObject) %>
+      <%= render partial: 'shared/digital', locals: {:dig_objs => @dig} %>
+    <% end %>
    <div class="col-8 pl-3">
     <% if  defined?(comp_id) && !comp_id && !@result['json']['ref_id'].blank? %>
       <span class='ref_id'>[<%=  t('archival_object._public.header.ref_id') %>: <%= @result['json']['ref_id'] %>]</span>

--- a/public/views/search/_only_facets.html.erb
+++ b/public/views/search/_only_facets.html.erb
@@ -23,7 +23,7 @@
     <%if type=="repository" %>
       <% next %>
     <% end %>
-    <h3 class="h5"><%= t("search_results.filter.#{type}") %></h3>
+    <h3 class="h5"><%= t("search_results.filter.#{type}._singular") %></h3>
     <ul class="small">
       <% facet_count = 0 %>
       <% h.each do |v, ct| %>

--- a/public/views/shared/_footer.html.erb
+++ b/public/views/shared/_footer.html.erb
@@ -91,7 +91,7 @@
             <div class="col-lg mb-3 mb-lg-0">
               <ul class="extensible-list">
                 <li>
-                  <strong>&#169; 2020 ArchivesSpace</strong>
+                  <strong>&#169; <%= DateTime.now.year %> ArchivesSpace</strong>
                 </li>
                 <li>
                   <a class="text-reset" href="http://archivesspace.org/">
@@ -113,7 +113,7 @@
           <a class="mb-2" href="https://www1.nyc.gov" title="Go to nyc.gov" target="_blank">
             <img class="mb-2" src="<%= AppConfig[:public_proxy_prefix] %>assets/images/nyc-bubble-logo.svg" width="90" alt="NYC Logo">
           </a>
-          <p class="fs-sm">City of New York - 2019 All Rights Reserved. NYC is a trademark and service
+          <p class="fs-sm">City of New York - <%= DateTime.now.year %> All Rights Reserved. NYC is a trademark and service
             mark of the City of New York.</p>
           <ul class="extensible-list horizontal fs-sm">
             <li>

--- a/public/views/shared/_single_note.html.erb
+++ b/public/views/shared/_single_note.html.erb
@@ -1,5 +1,5 @@
 <%  if !note_struct['note_text'].blank? %>
-    <div class="<%= type %> single_note" >
+    <div class="<%= type %> single_note pt-1" >
      <% unless defined?(notitle) &&  notitle %>
       <%=((defined?(title_desc))? "<h"+title_desc+">": '<h3>').html_safe %> <%= note_struct['label'] %> <%=((defined? (title_desc))? "</h"+title_desc+">" : '</h3>').html_safe%>
      <% end %>
@@ -7,9 +7,9 @@
        <% note_struct['subnotes'].each do |subnote| %>
          <div class="subnote <%= 'well' if subnote['jsonmodel_type'] == 'note_citation' %>">
            <% if subnote['jsonmodel_type'] == 'note_citation' %>
-             <h4><%= t('actions.cite') %></h4>
+             <h4 class="pt-1"><%= t('actions.cite') %></h4>
            <% elsif subnote['_title'] %>
-             <h4><%= subnote['_title'] %></h4>
+             <h4 class="pt-1"><%= subnote['_title'] %></h4>
            <% elsif subnote['_inline_label'] %>
              <span class='inline-label'><%= subnote['_inline_label'] %></span>
            <% end %>


### PR DESCRIPTION
- Fixed padding on the additional description section on collections page
- Fixed footer to reflect the current year
- Broke down the sidebar on agents page into sub-categories
- Changed 'Names' sidebar facet title on search results page to 'Name'
- Changed 'People' sidebar facet title on collections landing page to 'Person'
- Added 'Digital Objects' dropdown to collections with linked digital object
- Updated identifiers to remove colon.
- Fixed extra space before identifiers in archival objects