### PR TITLE
AB#640 - Contact from textual changes

### DIFF
--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -84,4 +84,6 @@ en:
   agent_software:
     _plural: Softwares
 
+  contact_form: Contact Us
+
 

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -83,7 +83,3 @@ en:
 
   agent_software:
     _plural: Softwares
-
-  contact_form: Contact Us
-
-

--- a/public/views/shared/_appointment_banner.html.erb
+++ b/public/views/shared/_appointment_banner.html.erb
@@ -3,11 +3,11 @@
     <div class="row">
       <div class="col-lg mb-3 mb-lg-0">
         <h2 class="h1">Set up a research appointment</h2>
-        <a class="btn btn-lg btn-primary mt-2 d-none d-lg-inline-block white-link" href="mailto:research@records.nyc.gov?subject=Research%20appointment" aria-hidden="true">Email Us</a>
+        <a class="btn btn-lg btn-primary mt-2 d-none d-lg-inline-block white-link" href="/contact" aria-hidden="true">Contact Us</a>
       </div>
       <div class="col-lg">
         <p>
-          Our collections are open for research. Contact us at research@records.nyc.gov. Our research room at 31 Chambers Street is currently closed to the public.
+          Our collections are open for research. Use our <a href="/contact">contact form</a> to start your research. Our research room at 31 Chambers Street is currently closed to the public.
         </p>
       </div>
       <!-- .col -->

--- a/public/views/shared/_footer.html.erb
+++ b/public/views/shared/_footer.html.erb
@@ -65,10 +65,8 @@
             <div class="col-lg mb-3 mb-lg-0">
               <ul class="extensible-list">
                 <li>
-                  <strong>Contact Us:
-                    <a class="text-reset" href="mailto:research@records.nyc.gov">
-                      <br>research@records.nyc.gov
-                    </a>
+                  <strong>
+                    <a class="text-reset" href="/contact">Contact us</a> to start your research
                   </strong>
                 </li><br>
                 <li>

--- a/public/views/shared/_header.html.erb
+++ b/public/views/shared/_header.html.erb
@@ -156,6 +156,11 @@
             Digital Collections <span class="fa fa-external-link-square-alt"></span>
           </a>
         </div>
+        <div class="nav-item">
+          <a class="nav-link" href="/contact" role="button">
+            Contact Us
+          </a>
+        </div>
         <!-- .nav-item -->
       </nav>
     </div>


### PR DESCRIPTION
- Updated homepage button from "Email us" to "Contact Us" and updated link
- Updated homepage text from "contact us at research@records.nyc.gov" to "use our <link>contact form</link> to start your research.
- Updated footer text to "Contact us to start your research"  and updated link
- Added 'Contact Us' to header navigation