### PR TITLE
Single Record Group Page

### DIFF
--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -70,7 +70,7 @@ en:
       badge_label: "%{level}"
 
   errors:
-    backend_down_message: ArchivesSpace is currently experiencing technical difficulties. We apologise for the inconvenience.
+    backend_down_message: ArchivesSpace is currently experiencing technical difficulties. We apologize for the inconvenience.
 
   agent_person:
     _plural: People
@@ -83,3 +83,7 @@ en:
 
   agent_software:
     _plural: Softwares
+
+  related_records:
+    _singular: "<small><b>%{count}</b> Related Record</small>"
+    _plural: "<small><b>%{count}</b> Related Records</small>"

--- a/public/views/accessions/show.html.erb
+++ b/public/views/accessions/show.html.erb
@@ -39,8 +39,8 @@
               Unprocessed collections may include protected information related to personal privacy, health information,
               and minors, as well as attorney-client privilege. In accordance with laws and regulations, this material
               will be reviewed prior to providing public access and certain records may be subject to redaction or other
-              measures that restrict access. Archival and library collections may also be restricted based on physical
-              condition.</p>
+              measures that restrict access. Archival and library collections may also be restricted or limited based on
+              physical condition, technical requirements, or format.</p>
           </div>
         </div>
 

--- a/public/views/classifications/_single_classification_idbadge.html.erb
+++ b/public/views/classifications/_single_classification_idbadge.html.erb
@@ -38,23 +38,10 @@
   <% url = result.uri %>
 <% end %>
 
-<%= (props.fetch(:full,false)? '<h1>' : '<h3 class="h-100">').html_safe %>
-  <% if !props.fetch(:full,false) %>
-    <div class="card m-2 h-100">
-      <button class="btn btn-md btn-light text-primary h-100 mx-1 my-2">
-        <% if result['json']['jsonmodel_type'] == "agent_corporate_entity" %>
-          <span class="fa fa-university">
-          </span>
-        <% else %>
-          <span class="fa fa-user">
-          </span>
-        <% end %>
-        <a  href="<%= app_prefix(url) %>">
-          <%== props.fetch(:infinite_item, false) ? result.parse_full_title(true) : result.display_string %>
-        </a>
-      </button>
-    </div>
-  <% else %>
-    <%= result.display_string %>
-  <% end %>
-<%= (props.fetch(:full,false)? '</h1>' : '</h3>').html_safe %>
+<% if !props.fetch(:full,false) %>
+  <a class="record-title" href="<%= app_prefix(url) %>">
+    <%== props.fetch(:infinite_item, false) ? result.parse_full_title(true) : result.display_string %>
+  </a>
+<% else %>
+  <%== result.display_string %>
+<% end %>

--- a/public/views/classifications/_single_classification_result.html.erb
+++ b/public/views/classifications/_single_classification_result.html.erb
@@ -1,0 +1,16 @@
+<div class="row matrix-gutter">
+  <div class="col-lg pt-2 mr-3">
+    <h3><%= render partial: 'classifications/single_classification_idbadge', locals: {:result => result, :props => props } %></h3>
+    <% if result['json'].has_key?('dates') || result['json'].has_key?('dates_of_existence') %>
+      <div class="dates pb-2">
+          <% dates = (result['json']['dates'] || result['json']['dates_of_existence']
+          ).collect {|date| parse_date(date)}.reject{|label, expression| expression.blank?} %>
+          <% unless dates.empty? %>
+            <strong><%= t('dates') %>: </strong>
+          <% end %>
+          <%= dates.collect {|label, expression| label.blank? ? expression : "#{label}#{expression}"}.join('; ') %>
+      </div>
+    <% end %>
+    <hr>
+  </div>
+</div>

--- a/public/views/classifications/show.html.erb
+++ b/public/views/classifications/show.html.erb
@@ -1,0 +1,19 @@
+<main role="main">
+  <section class="py-3">
+    <div class="container">
+      <h2><%= render partial: 'classifications/single_classification_idbadge', locals: {:result => @result, :props => {:full => true, :heading => true}} %></h2>
+      <div class="pb-1">
+        <% unless @results.blank? || @results['total_hits'] == 0 %>
+          <%== @results['total_hits'] == 1 ? t('related_records._singular', {:count => @results['total_hits']}) : t('related_records._plural', {:count => @results['total_hits']})%>
+        <% end %>
+      </div>
+      <hr>
+      <% unless @results.blank? || @results['total_hits'] == 0 %>
+        <% @results.records.each do |result| %>
+          <%= render partial: 'classifications/single_classification_result', locals: {:result => result, :props => {:full => false}} %>
+        <% end %>
+        <%= render partial: 'shared/pagination', locals: {:pager  => @pager}  %>
+      <% end %>
+    </div>
+  </section>
+</main>


### PR DESCRIPTION
This PR redesigns the single record group page to follow nyc-core-framework styles.

Additional fixes:
- Change "apologize" spelling in error page message
- Fix HTML issue with Agents idbadge not rendering special encoded characters (ex. &)
- Updated text for unprocessed archival collection note